### PR TITLE
init script

### DIFF
--- a/helios_server/helios_server
+++ b/helios_server/helios_server
@@ -12,8 +12,6 @@
 
 # Author: Abhay Jain <abhay.jain.cse11@itbhu.ac.in>
 #
-# Please remove the "Author" lines above and replace them
-# with your own name if you copy and modify this script.
 
 # Do NOT "set -e"
 


### PR DESCRIPTION
this is the init script to start helios server in daemon.
In this init script I have assumed that the master folder (helios-server) is located in /opt.
if the location is anywhere else then you just have to change
DAEMON=  python /opt/helios-server/manage.py runserver 0.0.0.0:8000
to DAEMON=  python "your helios-server location"/helios-server/manage.py runserver 0.0.0.0:8000

In the installation guidelines you can add  the following lines:
cp helios_server /etc/init.d
chmod +x /etc/init.d/helios_server
update-rc.d-insserv helios_server defaults
