### PR TITLE
A small fix for tghe `Voters & Ballots` crash

### DIFF
--- a/helios/models.py
+++ b/helios/models.py
@@ -867,8 +867,7 @@ class Voter(HeliosModel):
     """
     if not self.vote_hash:
       return None
-    
-    return CastVote.objects.get(vote_hash = self.vote_hash).vote_tinyhash
+    return CastVote.get_by_voter(self)[0].vote_tinyhash
 
   @property
   def election_uuid(self):


### PR DESCRIPTION
This line changed fixed a bug when people were voting multiple times. 
It's not the cleanest approach - I first thought of using Voter.last_cast_vote, but this method does not work as expected and using it does not solve the crash.

Thanks,

Benny
