### PR TITLE
Additionally check for the length of the array of proofs

### DIFF
--- a/helios/crypto/algs.py
+++ b/helios/crypto/algs.py
@@ -547,6 +547,10 @@ class EGCiphertext:
       
       overall_challenge is what all of the challenges combined should yield.
       """
+      if len(plaintexts) != len(proof.proofs):
+        print("bad number of proofs (expected %s, found %s)" % (len(plaintexts), len(proof.proofs)))
+        return False
+
       for i in range(len(plaintexts)):
         # if a proof fails, stop right there
         if not self.verify_encryption_proof(plaintexts[i], proof.proofs[i]):

--- a/helios/crypto/elgamal.py
+++ b/helios/crypto/elgamal.py
@@ -409,6 +409,10 @@ class Ciphertext:
       
       overall_challenge is what all of the challenges combined should yield.
       """
+      if len(plaintexts) != len(proof.proofs):
+        print("bad number of proofs (expected %s, found %s)" % (len(plaintexts), len(proof.proofs)))
+        return False
+
       for i in range(len(plaintexts)):
         # if a proof fails, stop right there
         if not self.verify_encryption_proof(plaintexts[i], proof.proofs[i]):


### PR DESCRIPTION
This commit addresses a vulnerability in the verification of Zero-Knowledge proofs of Helios.

This issue can be explain using the specification at http://documentation.heliosvoting.org/verification-specs/helios-v3-verification-specs

In the specification the function `verify_disjunctive_0..max_proof` assumes that the `disjunctive_proof` argument is an array of size `max+1`. The code was missing this condition and thus accepting a valid proof of `n ∈ 0..max+k` as a **valid** proof of `n ∈ 0..max`.

The code (which appears twice, one of them seems to be dead code) receives no `max` argument but instead should check that `plaintexts` and `proof.proofs` arrays are of the same length.
