### PR TITLE
Show aliased fields for one voter if using alias 

### DIFF
--- a/helios/datatypes/__init__.py
+++ b/helios/datatypes/__init__.py
@@ -186,7 +186,14 @@ class LDObject(object):
     
     def toDict(self, alternate_fields=None, complete=False):
         val = {}
-        for f in (alternate_fields or self.FIELDS):
+
+        fields = alternate_fields or self.FIELDS
+
+        if not self.structured_fields:
+            if self.wrapped_obj.alias != None:
+                fields = self.ALIASED_VOTER_FIELDS
+
+        for f in (alternate_fields or fields):
             # is it a structured subfield?
             if self.structured_fields.has_key(f):
                 val[f] = recursiveToDict(self.structured_fields[f])

--- a/helios/datatypes/__init__.py
+++ b/helios/datatypes/__init__.py
@@ -187,7 +187,7 @@ class LDObject(object):
     def toDict(self, alternate_fields=None, complete=False):
         val = {}
 
-        fields = alternate_fields or self.FIELDS
+        fields = self.FIELDS
 
         if not self.structured_fields:
             if self.wrapped_obj.alias != None:


### PR DESCRIPTION
Aliased fields are shown for voter listing ({HELIOS_HOST}/elections/<ELECTION_ID>/voters/), but not just for one voter ({HELIOS_HOST}/elections/<ELECTION_ID>/voters/<VOTER_ID>), when using alias.