### PR TITLE
Add ALLOWED_HOSTS setting

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -78,6 +78,12 @@ STATIC_URL = '/media/'
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = get_from_env('SECRET_KEY', 'replaceme')
 
+# If debug is set to false and ALLOWED_HOSTS is not declared, django raises  "CommandError: You must set settings.ALLOWED_HOSTS if DEBUG is False."
+# If in production, you got a bad request (400) error
+#More info: https://docs.djangoproject.com/en/1.7/ref/settings/#allowed-hosts (same for 1.6)
+
+ALLOWED_HOSTS = ['localhost'] # change to your allowed hosts
+
 # Secure Stuff
 if (get_from_env('SSL', '0') == '1'):
     SECURE_SSL_REDIRECT = True


### PR DESCRIPTION
After upgrading to django 1.6.10 I had to configure this setting. If I missed something, please let me know.
Thank you!