### PR TITLE
Prevent clickjacking attacks

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -118,6 +118,7 @@ MIDDLEWARE_CLASSES = (
 
     # secure a bunch of things
     'djangosecure.middleware.SecurityMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
 
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',


### PR DESCRIPTION
XFrameOptionsMiddleware added to prevent clickjacking. X-Frame-Options set to default (SAMEORIGIN). Fixes #85.