### PR TITLE
Remove gendered language from list trustees template

### DIFF
--- a/helios/templates/list_trustees.html
+++ b/helios/templates/list_trustees.html
@@ -8,7 +8,7 @@
 <p>
     Trustees are responsible for decrypting the election result.<br />
     Each trustee generates a keypair and submits the public portion to Helios.<br />
-    When it's time to decrypt, each trustee needs to provide his secret key.
+    When it's time to decrypt, each trustee needs to provide their secret key.
 </p>
 
 {% if not election.frozen_at %}


### PR DESCRIPTION
Hey all,

I just got to use Helios for the first time during the Node.js Foundation Individual Membership Director vote. I noticed that the explanation for trustees contained unnecessarily gendered language and wanted to fix it right away, because I couldn't find any reasons why only men could be one.

Best,
Stephan
