### PR TITLE
Prevent election edit from using existing shortname

### DIFF
--- a/helios/migrations/0003_auto_20160507_1948.py
+++ b/helios/migrations/0003_auto_20160507_1948.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('helios', '0002_castvote_cast_ip'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='election',
+            name='short_name',
+            field=models.CharField(unique=True, max_length=100),
+            preserve_default=True,
+        ),
+    ]

--- a/helios/models.py
+++ b/helios/models.py
@@ -45,7 +45,7 @@ class Election(HeliosModel):
   # later versions, at some point will upgrade to "2011/01/Election"
   datatype = models.CharField(max_length=250, null=False, default="legacy/Election")
   
-  short_name = models.CharField(max_length=100)
+  short_name = models.CharField(max_length=100, unique=True)
   name = models.CharField(max_length=250)
   
   ELECTION_TYPES = (

--- a/helios/views.py
+++ b/helios/views.py
@@ -10,7 +10,7 @@ from django.core.mail import send_mail
 from django.core.paginator import Paginator
 from django.core.exceptions import PermissionDenied
 from django.http import *
-from django.db import transaction
+from django.db import transaction, IntegrityError
 
 from mimetypes import guess_type
 
@@ -205,15 +205,11 @@ def election_new(request):
 
         user = get_user(request)
         election_params['admin'] = user
-        
-        election, created_p = Election.get_or_create(**election_params)
-      
-        if created_p:
-          # add Helios as a trustee by default
+        try:
+          election = Election.objects.create(**election_params)
           election.generate_trustee(ELGAMAL_PARAMS)
-          
           return HttpResponseRedirect(settings.SECURE_URL_HOST + reverse(one_election_view, args=[election.uuid]))
-        else:
+        except IntegrityError:
           error = "An election with short name %s already exists" % election_params['short_name']
       else:
         error = "No special characters allowed in the short name."
@@ -243,11 +239,12 @@ def one_election_edit(request, election):
       clean_data = election_form.cleaned_data
       for attr_name in RELEVANT_FIELDS:
         setattr(election, attr_name, clean_data[attr_name])
+      try:
+        election.save()
+        return HttpResponseRedirect(settings.SECURE_URL_HOST + reverse(one_election_view, args=[election.uuid]))
+      except IntegrityError:
+        error = "An election with short name %s already exists" % clean_data['short_name']
 
-      election.save()
-        
-      return HttpResponseRedirect(settings.SECURE_URL_HOST + reverse(one_election_view, args=[election.uuid]))
-  
   return render_template(request, "election_edit", {'election_form' : election_form, 'election' : election, 'error': error})
 
 @election_admin(frozen=False)


### PR DESCRIPTION
Existing short_name is checked just when adding election. A user can inadvertently use  an existing short_name when editing an election. This will make election url unusable, for instance.

@benadida I obviously didn't succeed when trying to, let's say, 'refactor' this branch to keep pull request #101 ongoing... I guess when re-writing history I shouldn't have done one push containing just the rebase   with master... I should have done it when my changes were committed, so github wouldn't think I was crazy and  closed that pull request...  Anyway, this issue remains and I think it would be nice to fix. In my institution we had problems with users editing an election and using the same short_name...