### PR TITLE
Add cast_ip field

### DIFF
--- a/helios/migrations/0002_castvote_cast_ip.py
+++ b/helios/migrations/0002_castvote_cast_ip.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('helios', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='castvote',
+            name='cast_ip',
+            field=models.GenericIPAddressField(null=True),
+            preserve_default=True,
+        ),
+    ]

--- a/helios/models.py
+++ b/helios/models.py
@@ -980,6 +980,9 @@ class CastVote(HeliosModel):
   verified_at = models.DateTimeField(null=True)
   invalidated_at = models.DateTimeField(null=True)
   
+  # auditing purposes, like too many votes from the same IP, if it isn't expected
+  cast_ip = models.GenericIPAddressField(null=True)
+
   @property
   def datatype(self):
     return self.voter.datatype.replace('Voter', 'CastVote')

--- a/helios/views.py
+++ b/helios/views.py
@@ -616,12 +616,22 @@ def one_election_cast_confirm(request, election):
   if voter:
     vote = datatypes.LDObject.fromDict(utils.from_json(encrypted_vote), type_hint='legacy/EncryptedVote').wrapped_obj
 
+    if 'HTTP_X_FORWARDED_FOR' in request.META:
+      # HTTP_X_FORWARDED_FOR sometimes have a comma delimited list of IP addresses
+      # Here we want the originating IP address
+      # See http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/x-forwarded-headers.html
+      # and https://en.wikipedia.org/wiki/X-Forwarded-For
+      cast_ip = request.META.get('HTTP_X_FORWARDED_FOR').split(',')[0].strip() or None
+    else:
+      cast_ip = request.META.get('REMOTE_ADDR', None)
+
     # prepare the vote to cast
     cast_vote_params = {
       'vote' : vote,
       'voter' : voter,
       'vote_hash': vote_fingerprint,
-      'cast_at': datetime.datetime.utcnow()
+      'cast_at': datetime.datetime.utcnow(),
+      'cast_ip': cast_ip
     }
 
     cast_vote = CastVote(**cast_vote_params)


### PR DESCRIPTION
@benadida  As I discussed in here https://groups.google.com/forum/#!searchin/helios-voting/cast_ip/helios-voting/VDHjssMZ1e8/nnBmm34qEgAJ, we want these info for auditing purposes,  like too many votes from the same IP address when this isn't expected (or otherwise). This field is implemented in the helios fork for the institution I work for and is working fine.

If you see problems, please, let me know. Thank you!


