### PR TITLE
Fix bias in voting booth random number generator

### DIFF
--- a/heliosbooth/js/jscrypto/random.js
+++ b/heliosbooth/js/jscrypto/random.js
@@ -26,7 +26,7 @@ Random.getRandomInteger = function(max) {
   var bit_length = max.bitLength();
   Random.setupGenerator();
   var random;
-  random = sjcl.random.randomWords(bit_length / 32, 0);
+  random = sjcl.random.randomWords(Math.ceil(bit_length / 32)+2, 0);
   // we get a bit array instead of a BigInteger in this case
   var rand_bi = new BigInt(sjcl.codec.hex.fromBits(random), 16);
   return rand_bi.mod(max);


### PR DESCRIPTION
**Purpose**: Addresses a bias in the Helios booth random number generator that could allow an attacker to discover how a voter voted from the public audit trail. 

1. The default group order `q` is 256 bits. To generate a random number in the range 0..q-1 for the disjunctive proof, the booth RNG currently generates 256 random bits and returns the result modulo q, which introduces a slight modulo bias. In a two candidate race the result is that the real challenge will be  larger than the simulated challenge with a _greater than_ 50% chance. 
2. Another more severe bias could manifest if the default group parameters were ever changed. Specifically if the bit length of the group order `q` is not a power of two, such as in a safe prime group, the `bit_length / 32` will generate up to 32 fewer bits than the bit length of `q` allowing an attacker to identify the simulated challenge in the voters encrypted ballot. 

**Explanation of proposed change**: 
The ideal fix would be not to use a modulo reduction to bring larger values inside the desired range, but rather loop the RNG until it produces a value less than `q`. But this approach would consume more entropy. Instead, we're proposing adopting the "simple modular method" for converting random bits to a random integer in the range 0..max-1 as described by NIST [1], which says given a max, and a security parameter s, the random bit generator shall generate |max|+s (or more) bits. The resulting bits are then returned modulo max. Because the returned value is likely much larger than max, the bias can be made negligible. A value of s=64 was recommended by NIST.

1. The `ceil()` guarantees that the number of random bits generated is equal to, or greater than bit_length.
2. The `+2` causes 64 additional random bits to be generated on top of the number of bits established in the previous step. Together this ensures that the number of random bits generated meets or exceeds |max|+64

**Reference**:
[1] Elaine Barker and John Kelsey. Recommendation for Random Number Generation Using Deterministic Random Bit Generators. Special Publication 800-90A, National Institute of Standards and Technology, 2012.