### PR TITLE
Prevent phishing attacks by setting noopener on external links

### DIFF
--- a/helios/templates/election_view.html
+++ b/helios/templates/election_view.html
@@ -46,7 +46,7 @@ this {{election.election_type}} is <u>not</u> featured on the front page.
 </div>
 
 {% if election.election_info_url %}
-<p style="font-size:1.5em;">[<a target="_blank" href="{{election.election_info_url}}">download candidate bios &amp; statements</a>]</p>
+<p style="font-size:1.5em;">[<a target="_blank" href="{{election.election_info_url}}" rel="noopener noreferrer">download candidate bios &amp; statements</a>]</p>
 {% endif %}
 
 <p align="center" style="font-size: 1.5em;">

--- a/heliosbooth/templates/question.html
+++ b/heliosbooth/templates/question.html
@@ -30,7 +30,7 @@ as many as you approve of
 {#if $T.question.answer_urls && $T.question.answer_urls[$T.answer_ordering[$T.answer$index]] && $T.question.answer_urls[$T.answer_ordering[$T.answer$index]] != ""}
 &nbsp;&nbsp;
 <span style="font-size: 12pt;">
-[<a target="_blank" href="{$T.question.answer_urls[$T.answer_ordering[$T.answer$index]]}">more info</a>]
+[<a target="_blank" href="{$T.question.answer_urls[$T.answer_ordering[$T.answer$index]]}" rel="noopener noreferrer">more info</a>]
 </span>
 {#/if}
 </div>


### PR DESCRIPTION
Due to a way `target="_blank"` works Helios Booth is vulnerable to phishing attacks by opening malicious candidate websites. This PR prevents those type of attacks by setting noopener/noreferrer on external links with `target="_blank"`.

More info: https://mathiasbynens.github.io/rel-noopener/

Disclaimer: this technique does not works in Safari and usage of [blankshield](https://github.com/danielstjules/blankshield) should be considered.