### PR TITLE
Initial attempt at dockerization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:2.7
+
+ENV PYTHONUNBUFFERED 1
+
+RUN DEBIAN_FRONTEND='noninteractive' apt-get update -qq && apt-get install -y postgresql-client-9.4
+ARG USER_ID=1000
+RUN adduser --disabled-password --quiet --uid ${USER_ID} --gecos Helios helios
+
+USER helios
+ENV HOME /home/helios
+
+RUN mkdir $HOME/server
+WORKDIR $HOME/server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+version: '2'
+services:
+  db:
+    environment:
+      - POSTGRES_USER=helios
+      - POSTGRES_PASSWORD
+    image: postgres
+    volumes:
+      - database:/var/lib/postgresql/data
+  web:
+    build:
+      context: .
+      args:
+        - USER_ID
+    environment:
+      - PGHOST=db
+      - WELCOME_MESSAGE
+    command: /home/helios/.local/bin/gunicorn wsgi:application -b 0.0.0.0:$PORT -w 8
+    volumes:
+      - .:/home/helios/server
+      - .pipcache:/home/helios/.cache/pip
+      - .pip:/home/helios/.local
+    ports:
+      - "9000:9000"
+    depends_on:
+      - db
+
+  worker:
+    build:
+      context: .
+      args:
+        - USER_ID
+    environment:
+      - PGHOST=db
+    command: python manage.py celeryd -E -B --beat --concurrency=1
+    volumes:
+      - .:/home/helios/server
+      - .pipcache:/home/helios/.cache/pip
+      - .pip:/home/helios/.local
+    depends_on:
+      - db
+volumes:
+  database:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,10 +3,10 @@ anyjson==0.3.3
 celery==3.1.18
 django-celery==3.1.16
 django-picklefield==0.3.0
-kombu==3.0.26
+kombu==3.0.30
 html5lib==0.999
 psycopg2==2.6.1
-pyparsing==1.5.7
+pyparsing==2.1.10
 python-dateutil>=1.5
 python-openid==2.2.5
 wsgiref==0.1.2


### PR DESCRIPTION
I put this here as a reference for how Helios can be done in docker, not necessarily for merging.
It changes the pip file since I based the server on a more recent Ubuntu, having the latest Python 2.7, and the older dependencies caused build errors.

I used docker-compose with three services, ran from separate web, celery and postgres containers.
the python code, .pip and .pipcache are shared with the host running docker, so that an update is done via a git pull or editing the code, with no need to rebuild a docker image. .

This should fill .pip and .pipcache in the install phase.
Those dirs should be created in the rootdir previously.
docker-compose run web pip install --user -r requirements.txt 

The .env file can contain various variables for example:

PORT=9000
WELCOME_MESSAGE="Hello from a self-hosted Helios instance"

Sorry I have not install script ready, I did this work a while ago, but did not polish and document it enough.