### PR TITLE
View voter list as it is in voter file upload

### DIFF
--- a/helios/stats_views.py
+++ b/helios/stats_views.py
@@ -47,8 +47,10 @@ def elections(request):
   elections_paginator = Paginator(elections, limit)
   elections_page = elections_paginator.page(page)
 
+  total_elections = elections_paginator.count
+
   return render_template(request, "stats_elections", {'elections' : elections_page.object_list, 'elections_page': elections_page,
-                                                      'limit' : limit, 'q': q})
+                                                      'limit' : limit, 'total_elections': total_elections, 'q': q})
     
 def recent_votes(request):
   user = require_admin(request)

--- a/helios/templates/voters_list.html
+++ b/helios/templates/voters_list.html
@@ -136,7 +136,7 @@ Voters {{voters_page.start_index}} - {{voters_page.end_index}} (of {{total_voter
 <td>{{voter.voter_login_id}}</td>
 <td>{{voter.voter_email}}</td>
 {% endif %}
-<td>{{voter.name}}</td>
+<td><img class="small-logo" src="/static/auth/login-icons/{{voter.voter_type}}.png" alt="{{voter.voter_type}}" /> {{voter.name}}</td>
 {% endif %}
 {% if election.use_voter_aliases %}
 <td>{{voter.alias}}</td>

--- a/helios/templates/voters_list.html
+++ b/helios/templates/voters_list.html
@@ -141,7 +141,7 @@ Voters {{voters_page.start_index}} - {{voters_page.end_index}} (of {{total_voter
 {% if election.use_voter_aliases %}
 <td>{{voter.alias}}</td>
 {% endif %}
-<td>{% if voter.vote_hash %}{{voter.vote_hash}} <span style="font-size:0.8em;">[<a href="{% url "helios.views.castvote_shortcut" vote_tinyhash=voter.vote_tinyhash %}">view</a>]</span>{% else %}&mdash;{% endif %}</td>
+<td><tt style="font-size: 1.4em;">{% if voter.vote_hash %}{{voter.vote_hash}} <span style="font-size:0.8em;">[<a href="{% url "helios.views.castvote_shortcut" vote_tinyhash=voter.vote_tinyhash %}">view</a>]</span>{% else %}&mdash;{% endif %}</tt></td>
 </tr>
 {% endfor %}
 </table>

--- a/helios/templates/voters_list.html
+++ b/helios/templates/voters_list.html
@@ -112,6 +112,11 @@ Voters {{voters_page.start_index}} - {{voters_page.end_index}} (of {{total_voter
 <table class="pretty">
 <tr>
 {% if admin_p or not election.use_voter_aliases %}
+{% if admin_p %}
+<th style="width: 80px;">Actions</th>
+<th>Login</th>
+<th>Email Address</th>
+{% endif %}
 <th>Name</th>
 {% endif %}
 
@@ -123,17 +128,20 @@ Voters {{voters_page.start_index}} - {{voters_page.end_index}} (of {{total_voter
 {% for voter in voters %}
 <tr>
 {% if admin_p or not election.use_voter_aliases %}
-<td>
 {% if admin_p %}
+<td style="white-space: nowrap;">
 [<a href="{% url "helios.views.voters_email" election.uuid %}?voter_id={{voter.voter_login_id}}">email</a>]
 [<a onclick="return confirm('are you sure you want to remove {{voter.name}} ?');" href="{% url "helios.views.voter_delete" election.uuid voter.uuid %}">x</a>]
+</td>
+<td>{{voter.voter_login_id}}</td>
+<td>{{voter.voter_email}}</td>
 {% endif %}
-<img class="small-logo" src="/static/auth/login-icons/{{voter.voter_type}}.png" alt="{{voter.voter_type}}" /> {{voter.name}}</td>
+<td>{{voter.name}}</td>
 {% endif %}
 {% if election.use_voter_aliases %}
 <td>{{voter.alias}}</td>
 {% endif %}
-<td><tt style="font-size: 1.4em;;">{% if voter.vote_hash %}{{voter.vote_hash}} <span style="font-size:0.8em;">[<a href="{% url "helios.views.castvote_shortcut" vote_tinyhash=voter.vote_tinyhash %}">view</a>]</span>{% else %}&mdash;{% endif %}</tt></td>
+<td>{% if voter.vote_hash %}{{voter.vote_hash}} <span style="font-size:0.8em;">[<a href="{% url "helios.views.castvote_shortcut" vote_tinyhash=voter.vote_tinyhash %}">view</a>]</span>{% else %}&mdash;{% endif %}</td>
 </tr>
 {% endfor %}
 </table>


### PR DESCRIPTION
In my helios voting instance, I registered 170 users. The users registered 980 elections and
500,000 voters. It is easier for users to check the voters list if the fields are the same and in the same order as they appear in the voter file upload.