### PR TITLE
Make cast vote email a template

### DIFF
--- a/server_ui/glue.py
+++ b/server_ui/glue.py
@@ -5,6 +5,7 @@ Glue some events together
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.conf import settings
+from helios.view_utils import render_template_raw
 import helios.views, helios.signals
 
 import views
@@ -12,30 +13,18 @@ import views
 def vote_cast_send_message(user, voter, election, cast_vote, **kwargs):
   ## FIXME: this doesn't work for voters that are not also users
   # prepare the message
-  subject = "%s - vote cast" % election.name
+  subject_template = 'email/cast_vote_subject.txt'
+  body_template = 'email/cast_vote_body.txt'
   
-  body = """
-You have successfully cast a vote in
-
-  %s
-  
-Your ballot is archived at:
-
-  %s
-""" % (election.name, helios.views.get_castvote_url(cast_vote))
-  
-  if election.use_voter_aliases:
-    body += """
-
-This election uses voter aliases to protect your privacy.
-Your voter alias is : %s    
-""" % voter.alias
-
-  body += """
-
---
-%s
-""" % settings.SITE_TITLE  
+  extra_vars = {
+    'election' : election,
+    'voter': voter,
+    'cast_vote': cast_vote,
+    'cast_vote_url': helios.views.get_castvote_url(cast_vote),
+    'custom_subject' : "%s - vote cast" % election.name
+  }
+  subject = render_template_raw(None, subject_template, extra_vars)
+  body = render_template_raw(None, body_template, extra_vars)
   
   # send it via the notification system associated with the auth system
   user.send_message(subject, body)

--- a/server_ui/templates/email/cast_vote_body.txt
+++ b/server_ui/templates/email/cast_vote_body.txt
@@ -1,0 +1,14 @@
+Dear {{voter.name}},
+
+You have successfully cast a vote in {{election.name}}.
+
+Your ballot is archived at: {{cast_vote_url}}
+
+{% if election.use_voter_aliases %}
+This election uses voter aliases to protect your privacy.
+Your voter alias is: {{voter.alias}}.
+{% endif %}
+
+--
+
+Helios

--- a/server_ui/templates/email/cast_vote_subject.txt
+++ b/server_ui/templates/email/cast_vote_subject.txt
@@ -1,0 +1,1 @@
+{{custom_subject|safe}}


### PR DESCRIPTION
I think it would be nice that this automatic e-mail be a template as well as the others sent via interface to the voter. It would allow some easier customisation to the message sent.