### PR TITLE
Fixed election sorting in admin elections page

### DIFF
--- a/helios/stats_views.py
+++ b/helios/stats_views.py
@@ -42,8 +42,7 @@ def elections(request):
   limit = int(request.GET.get('limit', 25))
   q = request.GET.get('q','')
 
-  elections = Election.objects.filter(name__icontains = q)
-  elections.all().order_by('-created_at')
+  elections = Election.objects.filter(name__icontains = q).order_by('-created_at')
   elections_paginator = Paginator(elections, limit)
   elections_page = elections_paginator.page(page)
 


### PR DESCRIPTION
This PR fixes the election sorting in the Admin -> Elections page.

Even though the problem is caused by [a missing assignment](https://github.com/benadida/helios-server/blob/master/helios/stats_views.py#L46), I decided to just chain the query filter.