### PR TITLE
Fix not allowed navigate top frame

### DIFF
--- a/helios/templates/election_keygenerator.html
+++ b/helios/templates/election_keygenerator.html
@@ -76,11 +76,23 @@ function show_sk() {
 }
 
 function download_sk() {
-    UTILS.open_window_with_content(jQuery.toJSON(SECRET_KEY), "application/json");
+    $('#pk_content').show();
+    $('#sk_content').html(jQuery.toJSON(SECRET_KEY));
+}
+
+function download_sk_to_file(filename) {
+    var element = document.createElement('a');
+    element.setAttribute('href','data:text/plain;charset=utf-8,'+ encodeURIComponent(jQuery.toJSON(SECRET_KEY)));
+    element.setAttribute('download', filename);
+    element.style.display = 'none';
+    document.body.appendChild(element);
+    element.click();
+    document.body.removeChild(element);
 }
 
 function show_pk() {
     $('#sk_download').hide();
+    $('#pk_content').hide();
     $('#pk_hash').show();
     $('#pk_form').show();
 }
@@ -101,7 +113,7 @@ function show_pk() {
 
 <span id="buttons"><button onclick="generate_keypair(); return false;" id="generate_button">Generate Election Keys</button></span>
 
-<br /><br />
+<br />
 If you've already generated a keypair, you can <a href="javascript:show_key_reuse()">reuse it</a>.
 </p>
 
@@ -126,11 +138,24 @@ Your key has been generated, but you may choose to<br /><a href="javascript:clea
 </span>
 
 <p>
-    <button style="font-size:16pt;" onclick="download_sk(); $('#pk_link').show();">Save your secret key</button>
+    <button style="font-size:16pt;" onclick="download_sk(); $('#pk_link').show();">Show my secret key</button>
 </p>
+</div>
 
-<p style="display: none;" id="pk_link">
-  <a href="javascript:show_pk();">ok, I've saved the key, let's move on</a>.
+<div style="display:none;" id="pk_content">
+    <p>Bellow is your trustee secret key content. Please copy its content and save it securely. <br>
+       You can also click to dowload it to a file.
+       And please don't lose it! Otherwise it will not be possible to decrypt the election tally.<br>
+    </p>
+    <textarea id="sk_content" rows="5" wrap="soft" cols="50" style="height: 25em;"></textarea>
+</div>
+
+<div style="display:none;" id="pk_link">
+<p>
+<a id="download_to_file" href="javascript:download_sk_to_file('trustee_key_for_{{election.name}}.txt');">download private key to a file</a>
+</p>
+<p>
+  <a href="javascript:show_pk();">ok, I've saved the key, let's move on</a>
 </p>
 </div>
 

--- a/helios/templates/trustee_check_sk.html
+++ b/helios/templates/trustee_check_sk.html
@@ -59,7 +59,7 @@ To verify that you have the right secret key, paste it here:
 <p>
 
 <form onsubmit="check_sk(this.secret_key.value); this.secret_key.value=''; return false;">
-<textarea name="secret_key" cols="60" rows ="5" wrap="soft">
+<textarea name="secret_key" cols="60" rows ="5" wrap="soft" style="height: 25em;">
 </textarea>
 <br />
 <input type="submit" value="check" />

--- a/helios/templates/trustee_decrypt_and_prove.html
+++ b/helios/templates/trustee_decrypt_and_prove.html
@@ -157,7 +157,7 @@ function reset() {
 
       <form onsubmit="return false;">
           <h3>FIRST STEP: enter your secret key</h3>
-          <textarea id="sk_textarea" cols="60" rows="5"></textarea>
+          <textarea id="sk_textarea" cols="60" rows="5" style="height: 25em;"></textarea>
       </form>
       <p id="tally_section">
           <button onclick="do_tally();">Generate partial decryption</button>
@@ -187,13 +187,11 @@ function reset() {
           When you're ready, you can submit this result to the server.
       </p>
       Your partial decryption:<br />
-      <form action="javascript:submit_result();">
-          <textarea id="result_textarea" cols="60" rows="5" wrap="soft"></textarea><br /><br />
-          <input type="submit" value="Upload decryption factors to server" />
-      </form>
-      <br />
-      <a href="javascript:reset()">reset and restart decryption process</a>
-      <br />
+      <p>
+          <textarea id="result_textarea" cols="60" rows="5" wrap="soft" style="height: 25em;"></textarea>
+          <button onclick="submit_result();">Upload decryption factors to server</button>
+      </p>
+      <p><a href="javascript:reset()">reset and restart decryption process</a></p>
   </div>
   
   <div id="done_div">


### PR DESCRIPTION
@benadida Google Chrome now throws "Not allowed to navigate top frame to data URL:" JavaScript exception when trying to save secret key. So, for security reasons, this is not allowed anymore and maybe other browsers may soon do the same.
Some information here:
https://ourcodeworld.com/articles/read/682/what-does-the-not-allowed-to-navigate-top-frame-to-data-url-javascript-exception-means-in-google-chrome
which links to the discussion in here:
https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/GbVcuwg_QjM%5B1-25%5D
I've tested the changes in Firerox 64.0.2, Chrome Version 71.0.3578.98 and Safari Version 12.0.3.
Instead of opening a new window, a textarea element is shown in the same window with the content.
Since I was doing such changes, I've also put a function to download the trustee key to a file. In terms of UX I think it is not that clear that he/she can save to a file, for instance, and that he/she should keep the key saved. In my institution we had a case where the election manager added a trustee and he/she didn't save the key... luckly, it was a minor one...
So, now it is possible to copy it from a textarea (as was possible before from a top frame data url) and also to download it direct to a file.
Looking forward to hear from you about the changes.
Thanks!