### PR TITLE
Remove unused import causing deprecation warning

### DIFF
--- a/helios/__init__.py
+++ b/helios/__init__.py
@@ -1,7 +1,5 @@
-
 from django.conf import settings
 from django.core.urlresolvers import reverse
-from helios.views import election_shortcut
 
 TEMPLATE_BASE = settings.HELIOS_TEMPLATE_BASE or "helios/templates/base.html"
 


### PR DESCRIPTION
@benadida This import is not being used and is causing a warning in the following form (following the idea of removing such warnings to easy future django upgrade):
RemovedInDjango19Warning: "ModelXYZ" doesn't declare an explicit app_label
Apparently this happens because it tries to import models before app configuration run.