### PR TITLE
Create a true Python list of Trustees

### DIFF
--- a/helios/models.py
+++ b/helios/models.py
@@ -510,7 +510,7 @@ class Election(HeliosModel):
     self.set_eligibility()
     
     # public key for trustees
-    trustees = Trustee.get_by_election(self)
+    trustees = list(Trustee.get_by_election(self))
     combined_pk = trustees[0].public_key
     for t in trustees[1:]:
       combined_pk = combined_pk * t.public_key
@@ -1171,7 +1171,7 @@ class Trustee(HeliosModel):
   
   @classmethod
   def get_by_election(cls, election):
-    return cls.objects.filter(election = election).order_by('id')
+    return cls.objects.filter(election = election)
 
   @classmethod
   def get_by_uuid(cls, uuid):

--- a/helios/models.py
+++ b/helios/models.py
@@ -1171,7 +1171,7 @@ class Trustee(HeliosModel):
   
   @classmethod
   def get_by_election(cls, election):
-    return cls.objects.filter(election = election)
+    return cls.objects.filter(election = election).order_by('id')
 
   @classmethod
   def get_by_uuid(cls, uuid):


### PR DESCRIPTION
Orders trustees by id to garantee access order on "freeze" method

When Helios fetches the trustees to combine the key, it causes a series of SELECTs over the database without a fixed order.

All these SELECT statements utilize only one filter parameter ("election_id = X"), attempting to retrieve data by means of "limit" and "offset" values, even though in PostgreSQL SELECTs with no ORDER BY statement do not garantee the same order for subsequent queries.

Reference:
https://www.postgresql.org/docs/9.1/queries-order.html