### PR TITLE
Fixes split select date time widget

### DIFF
--- a/helios/widgets.py
+++ b/helios/widgets.py
@@ -187,6 +187,23 @@ class SplitSelectDateTimeWidget(MultiWidget):
             return [value.date(), value.time().replace(microsecond=0)]
         return [None, None]
 
+    def compress(self, data_list):
+        """
+        Takes the values from the MultiWidget and passes them as a
+        list to this function. This function needs to compress the
+        list into a single object in order to be correctly rendered by the widget.
+        For instace, django.forms.widgets.SelectDateWidget.format_value(value)
+        expects a date object or a string, not a list.
+        This method was taken from helios/fields.py
+        """
+        if data_list:
+            import datetime
+            if not (data_list[0] and data_list[1]):
+                return None
+            return datetime.datetime.combine(*data_list)
+        return None
+
     def render(self, name, value, attrs=None, renderer=None):
+        value = self.compress(value)
         rendered_widgets = list(widget.render(name, value, attrs=attrs, renderer=renderer) for widget in self.widgets)
         return '<br/>'.join(rendered_widgets)

--- a/helios/widgets.py
+++ b/helios/widgets.py
@@ -179,7 +179,7 @@ class SplitSelectDateTimeWidget(MultiWidget):
     # See https://stackoverflow.com/questions/4324676/django-multiwidget-subclass-not-calling-decompress
     def value_from_datadict(self, data, files, name):
         if data.get(name, None) is None:
-            return [widget.value_from_datadict(data, files, name + '_%s' % i) for i, widget in enumerate(self.widgets)]
+            return [widget.value_from_datadict(data, files, name ) for widget in self.widgets]
         return self.decompress(data.get(name, None))
 
     def decompress(self, value):


### PR DESCRIPTION
Hi @benadida ! I've done some tests with the branch bens-cleaned-up-py3 running locally and as voting_start/end_date where not being saved I think the changes I've made fixes the problem. With theses changes I could save those dates, edit and extend voting with no problems. So I'm doing this PR into that branch, maybe you can test and check if those changes are appropriate. 
Nice to have you back with time to work on those big updates! 