### PR TITLE
The election object was not provided when the email is sent

### DIFF
--- a/helios/tasks.py
+++ b/helios/tasks.py
@@ -65,6 +65,7 @@ def single_voter_email(voter_uuid, subject_template, body_template, extra_vars={
     voter = Voter.objects.get(uuid=voter_uuid)
 
     the_vars = copy.copy(extra_vars)
+    the_vars.update({'election': voter.election})
     the_vars.update({'voter': voter})
 
     subject = render_template_raw(None, subject_template, the_vars)


### PR DESCRIPTION
The email that the user receives does not contain information about the election start and end, and this information exists in the email template