### PR TITLE
Fix XSS described in Backes 2016

### DIFF
--- a/heliosbooth/vote.html
+++ b/heliosbooth/vote.html
@@ -367,7 +367,7 @@ BOOTH.load_and_setup_election = function(election_url) {
     // the hash will be computed within the setup function call now
     $.get(election_url, function(raw_json) {
         // let's also get the metadata
-        $.getJSON(election_url + "/meta", {}, function(election_metadata) {
+        $.get(election_url + "/meta", function(election_metadata) {
           BOOTH.election_metadata = election_metadata;
           BOOTH.setup_election(raw_json, election_metadata);
           BOOTH.show_election();


### PR DESCRIPTION
Implementation-level Analysis of the JavaScript Helios Voting Client describes an XSS attack in the Helios booth. This PR fixes that. See #225. Note that this PR does not prevent the booth from getting external URLs, as that might be seen as a feature.

I also don't guarantee the security of the rest of this project, this PR just fixes one XSS.