### PR TITLE
feat: allow sending email directly via mailgun API as an option

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,8 @@ psycopg2==2.8.4
 celery==4.2.1
 django-picklefield==1.1.0
 
+django-anymail==8.4
+
 python-dateutil>=2.8
 unicodecsv==0.14.1
 bleach==3.3.0

--- a/settings.py
+++ b/settings.py
@@ -151,11 +151,19 @@ INSTALLED_APPS = (
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.sites',
+    'anymail',
     ## HELIOS stuff
     'helios_auth',
     'helios',
     'server_ui',
 )
+
+ANYMAIL = {
+    "MAILGUN_API_KEY": get_from_env('MAILGUN_API_KEY', None),
+}
+
+if ANYMAIL["MAILGUN_API_KEY"]:
+    EMAIL_BACKEND = "anymail.backends.mailgun.EmailBackend"
 
 ##
 ## HELIOS


### PR DESCRIPTION
This does not require the use of Mailgun, but if using mailgun, this allows emails to be sent via HTTP API, rather than SMTP.

For large scale emails, using an API can be a lot more efficient than SMTP.
