### PR TITLE
Open voter_stream in rb (binary) mode

### DIFF
--- a/helios/models.py
+++ b/helios/models.py
@@ -759,7 +759,7 @@ class VoterFile(models.Model):
       voter_stream = io.BytesIO(content)
     else:
       close = True
-      voter_stream = open(self.voter_file.path, "U")
+      voter_stream = open(self.voter_file.path, "rb")
 
     #reader = unicode_csv_reader(voter_stream)
     reader = unicodecsv.reader(voter_stream, encoding='utf-8')


### PR DESCRIPTION
... which is what unicodecsv.reader expects.

This reverts 35b5cdab4d2b87d024bd80b9b09b82eab7c3b4aa which causes the
tests to error out with

```
======================================================================
ERROR: test_add_voters_file (helios.tests.ElectionModelTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/helios-server/helios/tests.py", line 80, in test_add_voters_file
    vf.process()
  File "/tmp/helios-server/helios/models.py", line 806, in process
    voters = list(self.itervoters())
  File "/tmp/helios-server/helios/models.py", line 767, in itervoters
    for voter_fields in reader:
  File "/usr/lib/python3.6/site-packages/unicodecsv/py3.py", line 55, in __next__
    return self.reader.__next__()
  File "/usr/lib/python3.6/site-packages/unicodecsv/py3.py", line 51, in <genexpr>
    f = (bs.decode(encoding, errors=errors) for bs in f)
AttributeError: 'str' object has no attribute 'decode'
```