### PR TITLE
fix copy help_email when copying election

### DIFF
--- a/helios/views.py
+++ b/helios/views.py
@@ -960,6 +960,7 @@ def one_election_copy(request, election):
     name = "Copy of " + election.name,
     election_type = election.election_type,
     private_p = election.private_p,
+    help_email = election.help_email,
     description = election.description_bleached,
     questions = election.questions,
     eligibility = election.eligibility,


### PR DESCRIPTION
when making a copy of the election, the election email field is not copied