### PR TITLE
prefill voter credentials thru email url

### DIFF
--- a/helios/templates/email/result_body.txt
+++ b/helios/templates/email/result_body.txt
@@ -2,7 +2,7 @@ Dear {{voter.name}},
 
 The tally for {{election.name}} has been computed and released:
 
-  {{election_url}}
+  {{election_url}}#id_voter_id={{voter.voter_login_id}}&id_password={{voter.voter_password}}
 
 {{custom_message|safe}}
 

--- a/helios/templates/email/simple_body.txt
+++ b/helios/templates/email/simple_body.txt
@@ -5,7 +5,7 @@ Dear {{voter.name}},
 ========
 How to Vote
 
-Election URL:  {{election_vote_url}}
+Election URL:  {{election_vote_url}}#id_voter_id={{voter.voter_login_id}}&id_password={{voter.voter_password}}
 {% ifequal voter.voter_type "password" %}
 Your voter ID: {{voter.voter_login_id}}
 Your password: {{voter.voter_password}}

--- a/helios/templates/email/vote_body.txt
+++ b/helios/templates/email/vote_body.txt
@@ -3,7 +3,7 @@ Dear {{voter.name}},
 {{custom_message|safe}}
 
 Election URL (click to begin voting):
-{{election_vote_url}}
+{{election_vote_url}}#id_voter_id={{voter.voter_login_id}}&id_password={{voter.voter_password}}
 
 {% ifequal voter.voter_type "password" %}
 Your voter ID: {{voter.voter_login_id}}

--- a/server_ui/templates/base.html
+++ b/server_ui/templates/base.html
@@ -109,5 +109,16 @@ powered by <a href="http://heliosvoting.org">Helios Voting</a>.
       <script>
 	$(document).foundation();
       </script>     
+
+  <script>
+    var params = new URLSearchParams(document.location.hash.substring(1));
+    for (var [param_key, param_value] of params.entries()) {
+        var formElement = document.getElementById(param_key);
+        if (formElement) {
+            formElement.value = param_value;
+        }
+    }
+  </script>
+
 </body>
 </html>

--- a/server_ui/templates/base.html
+++ b/server_ui/templates/base.html
@@ -115,7 +115,11 @@ powered by <a href="http://heliosvoting.org">Helios Voting</a>.
     for (var [param_key, param_value] of params.entries()) {
         var formElement = document.getElementById(param_key);
         if (formElement) {
+          if (formElement.type === 'checkbox') {
+            formElement.checked = param_value;
+          } else {
             formElement.value = param_value;
+          }
         }
     }
   </script>


### PR DESCRIPTION
as of present, when users receive their credentials by mail, they have to manually fill out the login form.
this PR passes the user's credentials thru the email URL such as to have them automatically fill out in the login form.

a potential con here is that, with credentials going thru query parameters, this may leave the credentials exposed to an attacker with access to the voter's browser history.

as such, this patch makes for a potential trade-off between voter convenience vs security.
however, in real-life settings it would take attackers with access to a sufficient number of voters' browser histories to be able to influence election results, likely making this trade-off worthwhile, particularly for elections only open for a shorter period of time (such as is the case during live elections).
