### PR TITLE
Fixed issue in `create_user`

### DIFF
--- a/helios_auth/auth_systems/password.py
+++ b/helios_auth/auth_systems/password.py
@@ -20,9 +20,12 @@ PASSWORD_FORGOTTEN_URL_NAME = "auth@password@forgotten"
 
 def create_user(username, password, name = None):
   from helios_auth.models import User
-  
-  user = User.get_by_type_and_id('password', username)
-  if user:
+
+  try:
+    User.get_by_type_and_id('password', username)
+  except User.DoesNotExist:
+    pass
+  else:
     raise Exception('user exists')
   
   info = {'password' : password, 'name': name}


### PR DESCRIPTION
The function assumed that `User.get_by_type_and_id` returns a User instance or None. However, this called method raises a `helios_auth.models.User.DoesNotExist` exception.

This commit changes the behavior of `create_user` to match the behavior of `User.get_by_type_and_id`.