### PR TITLE
Add a link in the README.md to the main documentation URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Helios is an end-to-end verifiable voting system.
 
+The primary documentation site is at: <https://documentation.heliosvoting.org/>
+
 [![Travis Build Status](https://travis-ci.org/benadida/helios-server.svg?branch=master)](https://travis-ci.org/benadida/helios-server)
 
 [![Stories in Ready](https://badge.waffle.io/benadida/helios-server.png?label=ready&title=Ready)](https://waffle.io/benadida/helios-server)


### PR DESCRIPTION
I always expect a repositories `README.md` to either contain all necessary usage and design docs or link to it.

This is my best guess as to the proper link.