### PR TITLE
Update django version

### DIFF
--- a/helios/election_urls.py
+++ b/helios/election_urls.py
@@ -4,99 +4,99 @@ Helios URLs for Election related stuff
 Ben Adida (ben@adida.net)
 """
 
-from django.conf.urls import url
+from django.urls import path, re_path
 
 from helios import views
 from helios import election_url_names as names
 
 urlpatterns = [
     # election data that is cryptographically verified
-    url(r'^$', views.one_election, name=names.ELECTION_HOME),
+    path('', views.one_election, name=names.ELECTION_HOME),
 
     # metadata that need not be verified
-    url(r'^/meta$', views.one_election_meta, name=names.ELECTION_META),
+    path('/meta', views.one_election_meta, name=names.ELECTION_META),
     
     # edit election params
-    url(r'^/edit$', views.one_election_edit, name=names.ELECTION_EDIT),
-    url(r'^/schedule$', views.one_election_schedule, name=names.ELECTION_SCHEDULE),
-    url(r'^/extend$', views.one_election_extend, name=names.ELECTION_EXTEND),
-    url(r'^/archive$', views.one_election_archive, name=names.ELECTION_ARCHIVE),
-    url(r'^/copy$', views.one_election_copy, name=names.ELECTION_COPY),
+    path('/edit', views.one_election_edit, name=names.ELECTION_EDIT),
+    path('/schedule', views.one_election_schedule, name=names.ELECTION_SCHEDULE),
+    path('/extend', views.one_election_extend, name=names.ELECTION_EXTEND),
+    path('/archive', views.one_election_archive, name=names.ELECTION_ARCHIVE),
+    path('/copy', views.one_election_copy, name=names.ELECTION_COPY),
 
     # badge
-    url(r'^/badge$', views.election_badge, name=names.ELECTION_BADGE),
+    path('/badge', views.election_badge, name=names.ELECTION_BADGE),
 
     # adding trustees
-    url(r'^/trustees/$', views.list_trustees, name=names.ELECTION_TRUSTEES_HOME),
-    url(r'^/trustees/view$', views.list_trustees_view, name=names.ELECTION_TRUSTEES_VIEW),
-    url(r'^/trustees/new$', views.new_trustee, name=names.ELECTION_TRUSTEES_NEW),
-    url(r'^/trustees/add-helios$', views.new_trustee_helios, name=names.ELECTION_TRUSTEES_ADD_HELIOS),
-    url(r'^/trustees/delete$', views.delete_trustee, name=names.ELECTION_TRUSTEES_DELETE),
+    path('/trustees/', views.list_trustees, name=names.ELECTION_TRUSTEES_HOME),
+    path('/trustees/view', views.list_trustees_view, name=names.ELECTION_TRUSTEES_VIEW),
+    path('/trustees/new', views.new_trustee, name=names.ELECTION_TRUSTEES_NEW),
+    path('/trustees/add-helios', views.new_trustee_helios, name=names.ELECTION_TRUSTEES_ADD_HELIOS),
+    path('/trustees/delete', views.delete_trustee, name=names.ELECTION_TRUSTEES_DELETE),
     
     # trustee pages
-    url(r'^/trustees/(?P<trustee_uuid>[^/]+)/home$',
+    path('/trustees/<str:trustee_uuid>/home',
         views.trustee_home, name=names.ELECTION_TRUSTEE_HOME),
-    url(r'^/trustees/(?P<trustee_uuid>[^/]+)/sendurl$',
+    path('/trustees/<str:trustee_uuid>/sendurl',
         views.trustee_send_url, name=names.ELECTION_TRUSTEE_SEND_URL),
-    url(r'^/trustees/(?P<trustee_uuid>[^/]+)/keygenerator$',
+    path('/trustees/<str:trustee_uuid>/keygenerator',
         views.trustee_keygenerator, name=names.ELECTION_TRUSTEE_KEY_GENERATOR),
-    url(r'^/trustees/(?P<trustee_uuid>[^/]+)/check-sk$',
+    path('/trustees/<str:trustee_uuid>/check-sk',
         views.trustee_check_sk, name=names.ELECTION_TRUSTEE_CHECK_SK),
-    url(r'^/trustees/(?P<trustee_uuid>[^/]+)/upoad-pk$',
+    path('/trustees/<str:trustee_uuid>/upoad-pk',
         views.trustee_upload_pk, name=names.ELECTION_TRUSTEE_UPLOAD_PK),
-    url(r'^/trustees/(?P<trustee_uuid>[^/]+)/decrypt-and-prove$',
+    path('/trustees/<str:trustee_uuid>/decrypt-and-prove',
         views.trustee_decrypt_and_prove, name=names.ELECTION_TRUSTEE_DECRYPT_AND_PROVE),
-    url(r'^/trustees/(?P<trustee_uuid>[^/]+)/upload-decryption$',
+    path('/trustees/<str:trustee_uuid>/upload-decryption',
         views.trustee_upload_decryption, name=names.ELECTION_TRUSTEE_UPLOAD_DECRYPTION),
     
     # election voting-process actions
-    url(r'^/view$', views.one_election_view, name=names.ELECTION_VIEW),
-    url(r'^/result$', views.one_election_result, name=names.ELECTION_RESULT),
-    url(r'^/result_proof$', views.one_election_result_proof, name=names.ELECTION_RESULT_PROOF),
+    path('/view', views.one_election_view, name=names.ELECTION_VIEW),
+    path('/result', views.one_election_result, name=names.ELECTION_RESULT),
+    path('/result_proof', views.one_election_result_proof, name=names.ELECTION_RESULT_PROOF),
     # url(r'^/bboard$', views.one_election_bboard, name=names.ELECTION_BBOARD),
-    url(r'^/audited-ballots/$', views.one_election_audited_ballots, name=names.ELECTION_AUDITED_BALLOTS),
+    path('/audited-ballots/', views.one_election_audited_ballots, name=names.ELECTION_AUDITED_BALLOTS),
 
     # get randomness
-    url(r'^/get-randomness$', views.get_randomness, name=names.ELECTION_GET_RANDOMNESS),
+    path('/get-randomness', views.get_randomness, name=names.ELECTION_GET_RANDOMNESS),
 
     # server-side encryption
-    url(r'^/encrypt-ballot$', views.encrypt_ballot, name=names.ELECTION_ENCRYPT_BALLOT),
+    path('/encrypt-ballot', views.encrypt_ballot, name=names.ELECTION_ENCRYPT_BALLOT),
 
     # construct election
-    url(r'^/questions$', views.one_election_questions, name=names.ELECTION_QUESTIONS),
-    url(r'^/set_reg$', views.one_election_set_reg, name=names.ELECTION_SET_REG),
-    url(r'^/set_featured$', views.one_election_set_featured, name=names.ELECTION_SET_FEATURED),
-    url(r'^/save_questions$', views.one_election_save_questions, name=names.ELECTION_SAVE_QUESTIONS),
-    url(r'^/register$', views.one_election_register, name=names.ELECTION_REGISTER),
-    url(r'^/freeze$', views.one_election_freeze, name=names.ELECTION_FREEZE), # includes freeze_2 as POST target
+    path('/questions', views.one_election_questions, name=names.ELECTION_QUESTIONS),
+    path('/set_reg', views.one_election_set_reg, name=names.ELECTION_SET_REG),
+    path('/set_featured', views.one_election_set_featured, name=names.ELECTION_SET_FEATURED),
+    path('/save_questions', views.one_election_save_questions, name=names.ELECTION_SAVE_QUESTIONS),
+    path('/register', views.one_election_register, name=names.ELECTION_REGISTER),
+    path('/freeze', views.one_election_freeze, name=names.ELECTION_FREEZE), # includes freeze_2 as POST target
     
     # computing tally
-    url(r'^/compute_tally$', views.one_election_compute_tally, name=names.ELECTION_COMPUTE_TALLY),
-    url(r'^/combine_decryptions$', views.combine_decryptions, name=names.ELECTION_COMBINE_DECRYPTIONS),
-    url(r'^/release_result$', views.release_result, name=names.ELECTION_RELEASE_RESULT),
+    path('/compute_tally', views.one_election_compute_tally, name=names.ELECTION_COMPUTE_TALLY),
+    path('/combine_decryptions', views.combine_decryptions, name=names.ELECTION_COMBINE_DECRYPTIONS),
+    path('/release_result', views.release_result, name=names.ELECTION_RELEASE_RESULT),
     
     # casting a ballot before we know who the voter is
-    url(r'^/cast$', views.one_election_cast, name=names.ELECTION_CAST),
-    url(r'^/cast_confirm$', views.one_election_cast_confirm, name=names.ELECTION_CAST_CONFIRM),
-    url(r'^/password_voter_login$', views.password_voter_login, name=names.ELECTION_PASSWORD_VOTER_LOGIN),
-    url(r'^/cast_done$', views.one_election_cast_done, name=names.ELECTION_CAST_DONE),
+    path('/cast', views.one_election_cast, name=names.ELECTION_CAST),
+    path('/cast_confirm', views.one_election_cast_confirm, name=names.ELECTION_CAST_CONFIRM),
+    path('/password_voter_login', views.password_voter_login, name=names.ELECTION_PASSWORD_VOTER_LOGIN),
+    path('/cast_done', views.one_election_cast_done, name=names.ELECTION_CAST_DONE),
     
     # post audited ballot
-    url(r'^/post-audited-ballot', views.post_audited_ballot, name=names.ELECTION_POST_AUDITED_BALLOT),
+    re_path(r'^/post-audited-ballot', views.post_audited_ballot, name=names.ELECTION_POST_AUDITED_BALLOT),
     
     # managing voters
-    url(r'^/voters/$', views.voter_list, name=names.ELECTION_VOTERS_LIST),
-    url(r'^/voters/upload$', views.voters_upload, name=names.ELECTION_VOTERS_UPLOAD),
-    url(r'^/voters/upload-cancel$', views.voters_upload_cancel, name=names.ELECTION_VOTERS_UPLOAD_CANCEL),
-    url(r'^/voters/list$', views.voters_list_pretty, name=names.ELECTION_VOTERS_LIST_PRETTY),
-    url(r'^/voters/eligibility$', views.voters_eligibility, name=names.ELECTION_VOTERS_ELIGIBILITY),
-    url(r'^/voters/email$', views.voters_email, name=names.ELECTION_VOTERS_EMAIL),
-    url(r'^/voters/(?P<voter_uuid>[^/]+)$', views.one_voter, name=names.ELECTION_VOTER),
-    url(r'^/voters/(?P<voter_uuid>[^/]+)/delete$', views.voter_delete, name=names.ELECTION_VOTER_DELETE),
+    path('/voters/', views.voter_list, name=names.ELECTION_VOTERS_LIST),
+    path('/voters/upload', views.voters_upload, name=names.ELECTION_VOTERS_UPLOAD),
+    path('/voters/upload-cancel', views.voters_upload_cancel, name=names.ELECTION_VOTERS_UPLOAD_CANCEL),
+    path('/voters/list', views.voters_list_pretty, name=names.ELECTION_VOTERS_LIST_PRETTY),
+    path('/voters/eligibility', views.voters_eligibility, name=names.ELECTION_VOTERS_ELIGIBILITY),
+    path('/voters/email', views.voters_email, name=names.ELECTION_VOTERS_EMAIL),
+    path('/voters/<str:voter_uuid>', views.one_voter, name=names.ELECTION_VOTER),
+    path('/voters/<str:voter_uuid>/delete', views.voter_delete, name=names.ELECTION_VOTER_DELETE),
     
     # ballots
-    url(r'^/ballots/$', views.ballot_list, name=names.ELECTION_BALLOTS_LIST),
-    url(r'^/ballots/(?P<voter_uuid>[^/]+)/all$', views.voter_votes, name=names.ELECTION_BALLOTS_VOTER),
-    url(r'^/ballots/(?P<voter_uuid>[^/]+)/last$', views.voter_last_vote, name=names.ELECTION_BALLOTS_VOTER_LAST),
+    path('/ballots/', views.ballot_list, name=names.ELECTION_BALLOTS_LIST),
+    path('/ballots/<str:voter_uuid>/all', views.voter_votes, name=names.ELECTION_BALLOTS_VOTER),
+    path('/ballots/<str:voter_uuid>/last', views.voter_last_vote, name=names.ELECTION_BALLOTS_VOTER_LAST),
 
 ]

--- a/helios/models.py
+++ b/helios/models.py
@@ -197,7 +197,7 @@ class Election(HeliosModel):
   @property
   def description_bleached(self):
     return bleach.clean(self.description,
-                        tags=bleach.ALLOWED_TAGS + ['p', 'h4', 'h5', 'h3', 'h2', 'br', 'u'],
+                        tags=list(bleach.ALLOWED_TAGS) + ['p', 'h4', 'h5', 'h3', 'h2', 'br', 'u'],
                         strip=True,
                         strip_comments=True,
                         )

--- a/helios/signals.py
+++ b/helios/signals.py
@@ -1,16 +1,21 @@
 """
 Helios Signals
 
-Effectively callbacks that other apps can wait and be notified about
+Effectively callbacks that other apps can wait and be notified about.
+
+Named arguments for each signal:
+    election_created : "election"
+    vote_cast : "user", "voter", "election", "cast_vote"
+    election_tallied : "election"
 """
 
 import django.dispatch
 
 # when an election is created
-election_created = django.dispatch.Signal(providing_args=["election"])
+election_created = django.dispatch.Signal()
 
 # when a vote is cast
-vote_cast = django.dispatch.Signal(providing_args=["user", "voter", "election", "cast_vote"])
+vote_cast = django.dispatch.Signal()
 
 # when an election is tallied
-election_tallied = django.dispatch.Signal(providing_args=["election"])
+election_tallied = django.dispatch.Signal()

--- a/helios/stats_urls.py
+++ b/helios/stats_urls.py
@@ -4,15 +4,15 @@ Helios URLs for Election related stuff
 Ben Adida (ben@adida.net)
 """
 
-from django.conf.urls import url
+from django.urls import path
 
 from helios.stats_views import (home, force_queue, elections, recent_problem_elections, recent_votes)
 import helios.stats_url_names as names
 
 urlpatterns = [
-    url(r'^$', home, name=names.STATS_HOME),
-    url(r'^force-queue$', force_queue, name=names.STATS_FORCE_QUEUE),
-    url(r'^elections$', elections, name=names.STATS_ELECTIONS),
-    url(r'^problem-elections$', recent_problem_elections, name=names.STATS_ELECTIONS_PROBLEMS),
-    url(r'^recent-votes$', recent_votes, name=names.STATS_RECENT_VOTES),
+    path('', home, name=names.STATS_HOME),
+    path('force-queue', force_queue, name=names.STATS_FORCE_QUEUE),
+    path('elections', elections, name=names.STATS_ELECTIONS),
+    path('problem-elections', recent_problem_elections, name=names.STATS_ELECTIONS_PROBLEMS),
+    path('recent-votes', recent_votes, name=names.STATS_RECENT_VOTES),
 ]

--- a/helios/templates/election_audited_ballots.html
+++ b/helios/templates/election_audited_ballots.html
@@ -26,10 +26,10 @@ Audited Ballots {{offset_plus_one}} - {{offset_plus_limit}} &nbsp;&nbsp;
 <a href="?after={{next_after}}&offset={{offset_plus_limit}}">next {{limit}}</a> &nbsp;&nbsp;
 {% endif %}
 
-{% ifequal offset 0 %}
+{% if offset == 0 %}
 {% else %}
 <a href="?">back to start</a> &nbsp;&nbsp;
-{% endifequal %}
+{% endif %}
 {% if more_p %}
 <a href="?after={{next_after}}&offset={{next_offset}}">next {{limit}}</a>
 {% endif %}

--- a/helios/templates/election_bboard.html
+++ b/helios/templates/election_bboard.html
@@ -19,10 +19,10 @@ Voters {{offset_plus_one}} - {{offset_plus_limit}} &nbsp;&nbsp;
 <a href="{% url "election@bboard" election.uuid %}?after={{next_after}}&offset={{offset_plus_limit}}">next {{limit}}</a> &nbsp;&nbsp;
 {% endif %}
 
-{% ifequal offset 0 %}
+{% if offset == 0 %}
 {% else %}
 <a href="{% url "election@bboard" election.uuid %}">back to start</a> &nbsp;&nbsp;
-{% endifequal %}
+{% endif %}
 {% if more_p %}
 <a href="{% url "election@bboard" election.uuid %}?after={{next_after}}&offset={{next_offset}}">next {{limit}}</a>
 {% endif %}

--- a/helios/templates/election_new_2.html
+++ b/helios/templates/election_new_2.html
@@ -6,11 +6,11 @@
 var SECRET_KEY;
 
 function before_create() {
-{% ifequal election_type "one" %}
+{% if election_type == "one" %}
     return confirm('Have you made sure to copy the private key to a safe place?\n\nOnce you click OK, Helios will not be able to recover the secret key without your help!');
 {% else %}
     return true;
-{% endifequal %}
+{% endif %}
 }
 
 function generate_keypair() {
@@ -26,43 +26,43 @@ function generate_keypair() {
 
     $('#pk').val(jQuery.toJSON(SECRET_KEY.pk));
     
-{% ifequal election_type "one" %}
+{% if election_type == "one" %}
     $('#sk_textarea').val(jQuery.toJSON(SECRET_KEY));
     $('#sk_form').show();
 {% else %}
-{% ifequal election_type "helios" %}
+{% if election_type == "helios" %}
     $('#sk').val(jQuery.toJSON(SECRET_KEY));
-{% endifequal %}
-{% endifequal %}
+{% endif %}
+{% endif %}
 
     $('#submit').show();
 }
 
 $(document).ready(function() {
-{% ifnotequal election_type "multiple" %}
+{% if election_type != "multiple" %}
     $('#submit').hide();
-{% endifnotequal %}
+{% endif %}
     $('#sk_form').hide();
 });
 </script>
 
   <h2 class="title">Create a New Election: {{name}}</h2>
-{% ifequal election_type "helios" %}
+{% if election_type == "helios" %}
   <b>An election managed by Helios</b>.
 {% else %}
-{% ifequal election_type "one" %}
+{% if election_type == "one" %}
   <b>An election managed by you, the single administrator</b>.
 {% else %}
 <b>An election managed by multiple trustees</b>.
-{% endifequal %}
-{% endifequal %}
+{% endif %}
+{% endif %}
   <form class="prettyform" action="{% url "helios.views.election_new_3" %}" method="POST" id="create_election_form" onsubmit="return before_create();">
       <input type="hidden" name="csrf_token" value="{{csrf_token}}" />
       <input type="hidden" name="name" value="{{name}}" />
       <input type="hidden" name="public_key" id="pk" value="" />
       <input type="hidden" name="private_key" id="sk" value="" /><br />
 
-{% ifnotequal election_type "multiple" %}
+{% if election_type != "multiple" %}
   <label for="generate_key">&nbsp;</label><button onclick="generate_keypair(); return false;" id="generate_button">Generate Election Keys</button>
 {% else %}
 <div id="trustees">
@@ -73,12 +73,12 @@ $(document).ready(function() {
 <label for="">&nbsp;</label> <input type="text" name="trustee" /><br />
 <label for="">&nbsp;</label> <input type="text" name="trustee" /><br />
 </div>
-{% endifnotequal %}
+{% endif %}
 <br /><br />
 <label for="">&nbsp;</label>  <input type="submit" value="create" id="submit" />
   </form>
   <br /><br />
-{% ifequal election_type "one" %}
+{% if election_type == "one" %}
   <form style="padding-left: 200px;" id="sk_form" onsubmit="return false;">
       <input type="hidden" name="csrf_token" value="{{csrf_token}}" />
       Your Election's Secret Key:<br />
@@ -88,5 +88,5 @@ $(document).ready(function() {
       (You need to copy and paste this key and keep it safe,<br />
       otherwise you won't be able to tally your election.)
   </form>
-{% endifequal %}
+{% endif %}
 {% endblock %}

--- a/helios/templates/email/simple_body.txt
+++ b/helios/templates/email/simple_body.txt
@@ -6,9 +6,9 @@ Dear {{voter.name}},
 How to Vote
 
 Election URL:  {{election_vote_url}}
-{% ifequal voter.voter_type "password" %}
+{% if voter.voter_type == "password" %}
 Your voter ID: {{voter.voter_login_id}}
 Your password: {{voter.voter_password}}
 {% else %}
 Log in with your {{voter.voter_type}} account.
-{% endifequal %}
+{% endif %}

--- a/helios/templates/email/vote_body.txt
+++ b/helios/templates/email/vote_body.txt
@@ -5,12 +5,12 @@ Dear {{voter.name}},
 Election URL (click to begin voting):
 {{election_vote_url}}
 
-{% ifequal voter.voter_type "password" %}
+{% if voter.voter_type == "password" %}
 Your voter ID: {{voter.voter_login_id}}
 Your password: {{voter.voter_password}}
 {% else %}
 Log in with your {{voter.voter_type}} account.
-{% endifequal %}{% if voter.vote_hash %}
+{% endif %}{% if voter.vote_hash %}
 We have recorded your vote with ballot tracker:
 
   {{voter.vote_hash}}

--- a/helios/templates/voters_list.html
+++ b/helios/templates/voters_list.html
@@ -90,7 +90,7 @@ Prior Bulk Uploads:
 <p>
 <b>
 {% if election.num_cast_votes %}
-{{election.num_cast_votes}} cast vote{% ifequal election.num_cast_votes 1 %}{% else %}s{% endifequal %}
+{{election.num_cast_votes}} cast vote{% if election.num_cast_votes == 1 %}{% else %}s{% endif %}
 {% else %}
 no votes yet
 {% endif %}

--- a/helios/templates/voters_manage.html
+++ b/helios/templates/voters_manage.html
@@ -15,10 +15,10 @@ Voters {{offset_plus_one}} - {{offset_plus_limit}} &nbsp;&nbsp;
 <a href="./manage?after={{next_after}}&offset={{offset_plus_limit}}">next {{limit}}</a> &nbsp;&nbsp;
 {% endif %}
 
-{% ifequal offset 0 %}
+{% if offset == 0 %}
 {% else %}
 <a href="./manage">back to start</a> &nbsp;&nbsp;
-{% endifequal %}
+{% endif %}
 {% if more_p %}
 <a href="./manage?after={{next_after}}&offset={{next_offset}}">next {{limit}}</a>
 {% endif %}

--- a/helios/urls.py
+++ b/helios/urls.py
@@ -1,36 +1,36 @@
 # -*- coding: utf-8 -*-
-from django.conf.urls import url, include
+from django.urls import include, path
 
 from . import views, url_names as names
 
 urlpatterns = [
-  url(r'^autologin$', views.admin_autologin),
-  url(r'^testcookie$', views.test_cookie, name=names.COOKIE_TEST),
-  url(r'^testcookie_2$', views.test_cookie_2, name=names.COOKIE_TEST_2),
-  url(r'^nocookies$', views.nocookies, name=names.COOKIE_NO),
-  url(r'^stats/', include('helios.stats_urls')),
+  path('autologin', views.admin_autologin),
+  path('testcookie', views.test_cookie, name=names.COOKIE_TEST),
+  path('testcookie_2', views.test_cookie_2, name=names.COOKIE_TEST_2),
+  path('nocookies', views.nocookies, name=names.COOKIE_NO),
+  path('stats/', include('helios.stats_urls')),
 
   # election shortcut by shortname
-  url(r'^e/(?P<election_short_name>[^/]+)$', views.election_shortcut, name=names.ELECTION_SHORTCUT),
-  url(r'^e/(?P<election_short_name>[^/]+)/vote$', views.election_vote_shortcut, name=names.ELECTION_SHORTCUT_VOTE),
+  path('e/<str:election_short_name>', views.election_shortcut, name=names.ELECTION_SHORTCUT),
+  path('e/<str:election_short_name>/vote', views.election_vote_shortcut, name=names.ELECTION_SHORTCUT_VOTE),
 
   # vote shortcut
-  url(r'^v/(?P<vote_tinyhash>[^/]+)$', views.castvote_shortcut, name=names.CAST_VOTE_SHORTCUT),
+  path('v/<str:vote_tinyhash>', views.castvote_shortcut, name=names.CAST_VOTE_SHORTCUT),
 
   # vote by hash
-  url(r'^vh/(?P<vote_hash>[^/]+)$', views.castvote_fullhash_shortcut, name=names.CAST_VOTE_FULLHASH_SHORTCUT),
+  path('vh/<str:vote_hash>', views.castvote_fullhash_shortcut, name=names.CAST_VOTE_FULLHASH_SHORTCUT),
   
   # trustee login
-  url(r'^t/(?P<election_short_name>[^/]+)/(?P<trustee_email>[^/]+)/(?P<trustee_secret>[^/]+)$', views.trustee_login,
+  path('t/<str:election_short_name>/<str:trustee_email>/<str:trustee_secret>', views.trustee_login,
       name=names.TRUSTEE_LOGIN),
   
   # election
-  url(r'^elections/params$', views.election_params, name=names.ELECTIONS_PARAMS),
-  url(r'^elections/verifier$', views.election_verifier, name=names.ELECTIONS_VERIFIER),
-  url(r'^elections/single_ballot_verifier$', views.election_single_ballot_verifier, name=names.ELECTIONS_VERIFIER_SINGLE_BALLOT),
-  url(r'^elections/new$', views.election_new, name=names.ELECTIONS_NEW),
-  url(r'^elections/administered$', views.elections_administered, name=names.ELECTIONS_ADMINISTERED),
-  url(r'^elections/voted$', views.elections_voted, name=names.ELECTIONS_VOTED),
+  path('elections/params', views.election_params, name=names.ELECTIONS_PARAMS),
+  path('elections/verifier', views.election_verifier, name=names.ELECTIONS_VERIFIER),
+  path('elections/single_ballot_verifier', views.election_single_ballot_verifier, name=names.ELECTIONS_VERIFIER_SINGLE_BALLOT),
+  path('elections/new', views.election_new, name=names.ELECTIONS_NEW),
+  path('elections/administered', views.elections_administered, name=names.ELECTIONS_ADMINISTERED),
+  path('elections/voted', views.elections_voted, name=names.ELECTIONS_VOTED),
   
-  url(r'^elections/(?P<election_uuid>[^/]+)', include('helios.election_urls')),
+  path('elections/<str:election_uuid>', include('helios.election_urls')),
 ]

--- a/helios/view_utils.py
+++ b/helios/view_utils.py
@@ -6,7 +6,7 @@ Ben Adida (12-30-2008)
 
 from django.conf import settings
 from django.http import HttpResponse
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from django.template import loader
 # nicely update the wrapper function
 from functools import update_wrapper
@@ -51,7 +51,7 @@ def render_template(request, template_name, values = None, include_user=True):
   if not include_user:
     del vars_with_user['user']
 
-  return render_to_response('helios/templates/%s.html' % template_name, vars_with_user)
+  return render(request, 'helios/templates/%s.html' % template_name, vars_with_user)
 
 
 def render_template_raw(request, template_name, values=None):

--- a/helios/widgets.py
+++ b/helios/widgets.py
@@ -210,4 +210,4 @@ class SplitSelectDateTimeWidget(MultiWidget):
     def render(self, name, value, attrs=None, renderer=None):
         value = self.compress(value)
         rendered_widgets = list(widget.render(name, value, attrs=attrs, renderer=renderer) for widget in self.widgets)
-        return '<br/>'.join(rendered_widgets)
+        return mark_safe('<br/>'.join(rendered_widgets))

--- a/helios_auth/auth_systems/ldapauth.py
+++ b/helios_auth/auth_systems/ldapauth.py
@@ -12,7 +12,7 @@ from django.urls import re_path
 from django.core.mail import send_mail
 from django.http import HttpResponseRedirect
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 # some parameters to indicate that status updating is possible
 STATUS_UPDATES = False

--- a/helios_auth/auth_systems/ldapauth.py
+++ b/helios_auth/auth_systems/ldapauth.py
@@ -8,7 +8,7 @@ LDAP authentication relies on django-auth-ldap (https://django-auth-ldap.readthe
 
 from django import forms
 from django.conf import settings
-from django.conf.urls import url
+from django.urls import re_path
 from django.core.mail import send_mail
 from django.http import HttpResponseRedirect
 from django.urls import reverse
@@ -101,4 +101,4 @@ def check_constraint(constraint, user_info):
 def can_create_election(user_id, user_info):
   return True
 
-urlpatterns = [url(r'^ldap/login', ldap_login_view, name=LDAP_LOGIN_URL_NAME)]
+urlpatterns = [re_path(r'^ldap/login', ldap_login_view, name=LDAP_LOGIN_URL_NAME)]

--- a/helios_auth/auth_systems/password.py
+++ b/helios_auth/auth_systems/password.py
@@ -7,7 +7,7 @@ from django import forms
 from django.core.mail import send_mail
 from django.conf import settings
 from django.http import HttpResponseRedirect
-from django.conf.urls import url
+from django.urls import re_path
 
 from helios_auth import url_names
 
@@ -132,6 +132,6 @@ def can_create_election(user_id, user_info):
 
 
 urlpatterns = [
-  url(r'^password/login', password_login_view, name=PASSWORD_LOGIN_URL_NAME),
-  url(r'^password/forgot', password_forgotten_view, name=PASSWORD_FORGOTTEN_URL_NAME)
+  re_path(r'^password/login', password_login_view, name=PASSWORD_LOGIN_URL_NAME),
+  re_path(r'^password/forgot', password_forgotten_view, name=PASSWORD_FORGOTTEN_URL_NAME)
 ]

--- a/helios_auth/auth_systems/twitter.py
+++ b/helios_auth/auth_systems/twitter.py
@@ -4,7 +4,7 @@ Twitter Authentication
 
 from .oauthclient import client
 
-from django.conf.urls import url
+from django.urls import re_path
 from django.urls import reverse
 from django.http import HttpResponseRedirect
 
@@ -129,4 +129,4 @@ def can_create_election(user_id, user_info):
   return True
 
 
-urlpatterns = [url(r'^twitter/follow', follow_view, name=FOLLOW_VIEW_URL_NAME)]
+urlpatterns = [re_path(r'^twitter/follow', follow_view, name=FOLLOW_VIEW_URL_NAME)]

--- a/helios_auth/templates/login_box.html
+++ b/helios_auth/templates/login_box.html
@@ -3,12 +3,12 @@
 <a class="small button" href="{% url "auth@start" system_name=default_auth_system %}?return_url={{return_url}}">Log in</a></p>
 {% else %}
 {% for auth_system in enabled_auth_systems %}
-{% ifequal auth_system "password" %}
+{% if auth_system == "password" %}
 {% else %}
 <p>
     <a href="{{SECURE_URL_HOST}}{% url "auth@start" system_name=auth_system %}?return_url={{return_url}}" style="font-size: 1.4em;">
 <img style="height: 35px; border: 0px;" src="/static/auth/login-icons/{{auth_system}}.png" alt="{{auth_system}}" /> {{auth_system}}
-{% endifequal %}
+{% endif %}
 </a>
 </p>
 {% endfor %}

--- a/helios_auth/urls.py
+++ b/helios_auth/urls.py
@@ -5,20 +5,20 @@ Authentication URLs
 Ben Adida (ben@adida.net)
 """
 
-from django.conf.urls import url
+from django.urls import path, re_path
 
 from settings import AUTH_ENABLED_SYSTEMS
 from . import views, url_names
 
 urlpatterns = [
     # basic static stuff
-    url(r'^$', views.index, name=url_names.AUTH_INDEX),
-    url(r'^logout$', views.logout, name=url_names.AUTH_LOGOUT),
-    url(r'^start/(?P<system_name>.*)$', views.start, name=url_names.AUTH_START),
+    path('', views.index, name=url_names.AUTH_INDEX),
+    path('logout', views.logout, name=url_names.AUTH_LOGOUT),
+    re_path(r'^start/(?P<system_name>.*)$', views.start, name=url_names.AUTH_START),
     # weird facebook constraint for trailing slash
-    url(r'^after/$', views.after, name=url_names.AUTH_AFTER),
-    url(r'^why$', views.perms_why, name=url_names.AUTH_WHY),
-    url(r'^after_intervention$', views.after_intervention, name=url_names.AUTH_AFTER_INTERVENTION),
+    path('after/', views.after, name=url_names.AUTH_AFTER),
+    path('why', views.perms_why, name=url_names.AUTH_WHY),
+    path('after_intervention', views.after_intervention, name=url_names.AUTH_AFTER_INTERVENTION),
 ]
 
 # password auth

--- a/helios_auth/view_utils.py
+++ b/helios_auth/view_utils.py
@@ -6,7 +6,7 @@ Ben Adida (12-30-2008)
 
 from django.conf import settings
 from django.http import HttpResponse
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from django.template import loader
 
 import helios_auth
@@ -42,7 +42,7 @@ def prepare_vars(request, values):
 def render_template(request, template_name, values=None):
   vars_with_user = prepare_vars(request, values or {})
 
-  return render_to_response('helios_auth/templates/%s.html' % template_name, vars_with_user)
+  return render(request, 'helios_auth/templates/%s.html' % template_name, vars_with_user)
 
 
 def render_template_raw(request, template_name, values=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,28 +1,28 @@
-Django==2.2.28
-django_webtest>=1.9.8
+Django==5.0
+django-webtest>=1.9.11
 
 gunicorn==22.0.0
 
-dj_database_url==0.5.0
+dj-database-url==2.2.0
 psycopg2==2.9.9
 
-celery==4.4.7
-django-picklefield==1.1.0
+celery==5.4.0
+django-picklefield==3.2
 
-django-anymail==8.4
+django-anymail==11.0.1
 
-python-dateutil==2.8.2
+python-dateutil==2.9.0
 unicodecsv==0.14.1
-bleach==3.3.1
+bleach==6.1.0
 validate_email==1.3
-pycryptodome==3.12.0
+pycryptodome==3.20.0
 
 python3-openid==3.2.0
 boto==2.49.0
-django-ses==0.8.14
+django-ses==4.1.0
 oauth2client==4.1.3
-rollbar==0.16.2
+rollbar==1.0.0
 
 #ldap auth
-django_auth_ldap==4.0.0
-python-ldap==3.4.3
+django-auth-ldap==4.8.0
+python-ldap==3.4.4

--- a/server_ui/urls.py
+++ b/server_ui/urls.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-from django.conf.urls import url
+from django.urls import path
 
 from .views import home, about, docs, faq, privacy
 
 urlpatterns = [
-  url(r'^$', home),
-  url(r'^about$', about),
-  url(r'^docs$', docs),
-  url(r'^faq$', faq),
-  url(r'^privacy$', privacy),
+  path('', home),
+  path('about', about),
+  path('docs', docs),
+  path('faq', faq),
+  path('privacy', privacy),
 ]

--- a/server_ui/view_utils.py
+++ b/server_ui/view_utils.py
@@ -5,7 +5,7 @@ Ben Adida (2009-07-18)
 """
 
 from django.conf import settings
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 
 from helios_auth.security import get_user
 
@@ -23,5 +23,5 @@ def render_template(request, template_name, values = None):
   if 'csrf_token' in request.session:
     vars_with_user['csrf_token'] = request.session['csrf_token']
   
-  return render_to_response('server_ui/templates/%s.html' % template_name, vars_with_user)
+  return render(request, 'server_ui/templates/%s.html' % template_name, vars_with_user)
   

--- a/settings.py
+++ b/settings.py
@@ -224,7 +224,7 @@ HELIOS_PRIVATE_DEFAULT = False
 # authentication systems enabled
 # AUTH_ENABLED_SYSTEMS = ['password','facebook','twitter', 'google', 'yahoo']
 AUTH_ENABLED_SYSTEMS = get_from_env('AUTH_ENABLED_SYSTEMS',
-                                    get_from_env('AUTH_ENABLED_AUTH_SYSTEMS', 'password,google,facebook')
+                                    get_from_env('AUTH_ENABLED_AUTH_SYSTEMS', 'ldap,password,google,facebook')
                                     ).split(",")
 AUTH_DEFAULT_SYSTEM = get_from_env('AUTH_DEFAULT_SYSTEM', get_from_env('AUTH_DEFAULT_AUTH_SYSTEM', None))
 

--- a/settings.py
+++ b/settings.py
@@ -62,6 +62,8 @@ if get_from_env('DATABASE_URL', None):
 # system time zone.
 TIME_ZONE = 'America/Los_Angeles'
 
+USE_TZ = False
+
 # Language code for this installation. All choices can be found here:
 # http://www.i18nguy.com/unicode/language-identifiers.html
 LANGUAGE_CODE = 'en-us'

--- a/settings.py
+++ b/settings.py
@@ -55,6 +55,9 @@ if get_from_env('DATABASE_URL', None):
     DATABASES['default'] = dj_database_url.config(conn_max_age=600, ssl_require=True)
     DATABASES['default']['ENGINE'] = 'django.db.backends.postgresql'
 
+# explicitly set the default auto-created primary field to silence warning models.W042
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
 # although not all choices may be available on all operating systems.

--- a/settings.py
+++ b/settings.py
@@ -43,7 +43,7 @@ SHOW_USER_INFO = (get_from_env('SHOW_USER_INFO', '1') == '1')
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'ENGINE': 'django.db.backends.postgresql',
         'NAME': 'helios',
         'CONN_MAX_AGE': 600,
     },
@@ -53,7 +53,7 @@ DATABASES = {
 if get_from_env('DATABASE_URL', None):
     import dj_database_url
     DATABASES['default'] = dj_database_url.config(conn_max_age=600, ssl_require=True)
-    DATABASES['default']['ENGINE'] = 'django.db.backends.postgresql_psycopg2'
+    DATABASES['default']['ENGINE'] = 'django.db.backends.postgresql'
 
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name

--- a/urls.py
+++ b/urls.py
@@ -1,19 +1,19 @@
 # -*- coding: utf-8 -*-
 from django.conf import settings
-from django.conf.urls import url, include
+from django.urls import include, path, re_path
 from django.views.static import serve
 
 urlpatterns = [
-    url(r'^auth/', include('helios_auth.urls')),
-    url(r'^helios/', include('helios.urls')),
+    path('auth/', include('helios_auth.urls')),
+    path('helios/', include('helios.urls')),
 
     # SHOULD BE REPLACED BY APACHE STATIC PATH
-    url(r'booth/(?P<path>.*)$', serve, {'document_root' : settings.ROOT_PATH + '/heliosbooth'}),
-    url(r'verifier/(?P<path>.*)$', serve, {'document_root' : settings.ROOT_PATH + '/heliosverifier'}),
+    re_path(r'booth/(?P<path>.*)$', serve, {'document_root' : settings.ROOT_PATH + '/heliosbooth'}),
+    re_path(r'verifier/(?P<path>.*)$', serve, {'document_root' : settings.ROOT_PATH + '/heliosverifier'}),
 
-    url(r'static/auth/(?P<path>.*)$', serve, {'document_root' : settings.ROOT_PATH + '/helios_auth/media'}),
-    url(r'static/helios/(?P<path>.*)$', serve, {'document_root' : settings.ROOT_PATH + '/helios/media'}),
-    url(r'static/(?P<path>.*)$', serve, {'document_root' : settings.ROOT_PATH + '/server_ui/media'}),
+    re_path(r'static/auth/(?P<path>.*)$', serve, {'document_root' : settings.ROOT_PATH + '/helios_auth/media'}),
+    re_path(r'static/helios/(?P<path>.*)$', serve, {'document_root' : settings.ROOT_PATH + '/helios/media'}),
+    re_path(r'static/(?P<path>.*)$', serve, {'document_root' : settings.ROOT_PATH + '/server_ui/media'}),
 
-    url(r'^', include('server_ui.urls')),
+    path('', include('server_ui.urls')),
 ]


### PR DESCRIPTION
### Upgrade from Django 2 to Django 5

Hello everyone! I'm working on upgrading the Voting System that is used in University of Campinas (Brazil), which was based on an older version of Helios  (that was still in Python 2). To avoid starting the new project with technological dependencies, we upgraded the current Helios project from Django 2 to Django 5 and Celery 4 to 5 (and also to Python 3.11, since Django 5 doesn't support Python 3.8).

### Tests

All automated tests passed the changes. Beyond that, we also performed manual use-cases:

- create election
- add questions
- bulk upload voters (password)
- freeze ballot and open election
- email voters — Time to Vote
- vote on election (cast ballot)
- post an audited ballot to tracking center
- verify audited ballot
- compute encrypted tally
- compute results
- release results
- email voters — Election Result  
- verify election tally

It all worked the same as with the current Helios version.

### Changes

Here is a summary of the reason for each change made to the project:

|Altered File|Reason|Relevant Docs|
|------------|------|-------------|
|`helios/election_urls.py`|`django.conf.urls.url()` alias of `django.urls.re_path()` deprecated in 3.1|https://docs.djangoproject.com/en/5.0/releases/3.1/#id2|
|`helios/models.py`|Newer version of `bleach` changed type of `ALLOWED_TAGS` from `list` to `frozenset`|https://github.com/mozilla/bleach/commit/05d3a4a796e9413014510287d6426b3dd4226ba5#diff-961169d4b22958d5c522943ac713d921ade9ba1ce236c44187444ed1835761b4,|
|`helios/signals.py`|The purely documentational `providing_args` argument for `django.dispatch.Signal` deprecated in 3.1|https://docs.djangoproject.com/en/5.0/releases/3.1/#id2|
|`helios/stats_urls.py`|`django.conf.urls.url()` alias of `django.urls.re_path()` deprecated in 3.1|https://docs.djangoproject.com/en/5.0/releases/3.1/#id2|
|`helios/templates/election_audited_ballots.html`|`{% ifequal %}` and `{% ifnotequal %}` template tags deprecated in 3.1 (use `{% if == %}` and `{% if != %}`)|https://docs.djangoproject.com/en/5.0/releases/3.1/#id2|
|`helios/templates/election_bboard.html`|`{% ifequal %}` and `{% ifnotequal %}` template tags deprecated in 3.1 (use `{% if == %}` and `{% if != %}`)|https://docs.djangoproject.com/en/5.0/releases/3.1/#id2|
|`helios/templates/election_new_2.html`|`{% ifequal %}` and `{% ifnotequal %}` template tags deprecated in 3.1 (use `{% if == %}` and `{% if != %}`)|https://docs.djangoproject.com/en/5.0/releases/3.1/#id2|
|`helios/templates/email/simple_body.txt`|`{% ifequal %}` and `{% ifnotequal %}` template tags deprecated in 3.1 (use `{% if == %}` and `{% if != %}`)|https://docs.djangoproject.com/en/5.0/releases/3.1/#id2|
|`helios/templates/email/vote_body.txt`|`{% ifequal %}` and `{% ifnotequal %}` template tags deprecated in 3.1 (use `{% if == %}` and `{% if != %}`)|https://docs.djangoproject.com/en/5.0/releases/3.1/#id2|
|`helios/templates/voters_list.html`|`{% ifequal %}` and `{% ifnotequal %}` template tags deprecated in 3.1 (use `{% if == %}` and `{% if != %}`)|https://docs.djangoproject.com/en/5.0/releases/3.1/#id2|
|`helios/templates/voters_manage.html`|`{% ifequal %}` and `{% ifnotequal %}` template tags deprecated in 3.1 (use `{% if == %}` and `{% if != %}`)|https://docs.djangoproject.com/en/5.0/releases/3.1/#id2|
|`helios/urls.py`|`django.conf.urls.url()` alias of `django.urls.re_path()` deprecated in 3.1|https://docs.djangoproject.com/en/5.0/releases/3.1/#id2|
|`helios/view_utils.py`|`django.shortcuts.render_to_response()` deprecated in 2.0|https://docs.djangoproject.com/en/5.0/releases/2.0/#deprecated-features-2-0|
|`helios/widgets.py`|Concatenating a safe string with another safe bytestring or safe string is safe. Otherwise, the result is no longer safe.|https://docs.djangoproject.com/en/5.0/_modules/django/utils/safestring/#SafeString|
|`helios_auth/auth_systems/ldapauth.py`|`django.conf.urls.url()` alias of `django.urls.re_path()` deprecated in 3.1|https://docs.djangoproject.com/en/5.0/releases/3.1/#id2|
|`helios_auth/auth_systems/ldapauth.py`|`django.utils.translation.ugettext()` alias of `django.utils.translation.gettext()` deprecated in 3.0|https://docs.djangoproject.com/en/5.0/releases/3.0/#id3|
|`helios_auth/auth_systems/password.py`|`django.conf.urls.url()` alias of `django.urls.re_path()` deprecated in 3.1|https://docs.djangoproject.com/en/5.0/releases/3.1/#id2|
|`helios_auth/auth_systems/twitter.py`|`django.conf.urls.url()` alias of `django.urls.re_path()` deprecated in 3.1|https://docs.djangoproject.com/en/5.0/releases/3.1/#id2|
|`helios_auth/templates/login_box.html`|`{% ifequal %}` and `{% ifnotequal %}` template tags deprecated in 3.1 (use `{% if == %}` and `{% if != %}`)|https://docs.djangoproject.com/en/5.0/releases/3.1/#id2|
|`helios_auth/urls.py`|`django.conf.urls.url()` alias of `django.urls.re_path()` deprecated in 3.1|https://docs.djangoproject.com/en/5.0/releases/3.1/#id2|
|`helios_auth/view_utils.py`|`django.shortcuts.render_to_response()` deprecated in 2.0|https://docs.djangoproject.com/en/5.0/releases/2.0/#deprecated-features-2-0|
|`server_ui/urls.py`|`django.conf.urls.url()` alias of `django.urls.re_path()` deprecated in 3.1|https://docs.djangoproject.com/en/5.0/releases/3.1/#id2|
|`server_ui/view_utils.py`|`django.shortcuts.render_to_response()` deprecated in 2.0|https://docs.djangoproject.com/en/5.0/releases/2.0/#deprecated-features-2-0|
|`requirements.txt`|General update of the whole environment|-|
|`settings.py`|Default value of `USE_TZ` setting changed from False to True in 5.0|https://docs.djangoproject.com/en/5.0/releases/5.0/#features-removed-in-5-0|
|`settings.py`|`DEFAULT_AUTO_FIELD` must be explicitly set for auto-created primary keys (throws warning `models.W042` - https://docs.djangoproject.com/en/5.0/ref/checks/#models)|https://docs.djangoproject.com/en/5.0/releases/3.2/#customizing-type-of-auto-created-primary-keys|
|`settings.py`|`django.db.backends.postgresql_psycopg2` module deprecated in 2.0 (use `django.db.backends.postgresql`)|https://docs.djangoproject.com/en/5.0/releases/2.0/#id1|
|`urls.py`|`django.conf.urls.url()` alias of `django.urls.re_path()` deprecated in 3.1|https://docs.djangoproject.com/en/5.0/releases/3.1/#id2|
