### PR TITLE
Update psycopg2 to support Python 3.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ django-webtest>=1.9.11
 gunicorn==22.0.0
 
 dj-database-url==2.2.0
-psycopg2==2.9.9
+psycopg2==2.9.10
 
 celery==5.4.0
 django-picklefield==3.2


### PR DESCRIPTION
To be able to use Python 3.13 psycopg2 has to be updated to 2.9.10