### PR TITLE
fix: Use integer division when determining winner in absolute questions

### DIFF
--- a/helios/models.py
+++ b/helios/models.py
@@ -640,7 +640,7 @@ class Election(HeliosModel):
 
     # if max = 1, then depends on absolute or relative
     if question['result_type'] == 'absolute':
-      if counts[0][1] >=  (num_cast_votes/2 + 1):
+      if counts[0][1] >=  (num_cast_votes//2 + 1):
         return [counts[0][0]]
       else:
         return []


### PR DESCRIPTION
Py2/3 discrepancy in behaviour where Py2 would perform integer division, while Py3 will perform an implicit conversion to floats.

This causes a bug where the narrowest supermajority may not win an election in a case where there is an odd number of votes.


fixes: #417
