### PR TITLE
fix: silence invalid escape sequence warnings

### DIFF
--- a/helios/utils.py
+++ b/helios/utils.py
@@ -109,7 +109,7 @@ def xss_strip_all_tags(s):
                     return str(entity, "iso-8859-1")
         return text # leave as is
         
-    return re.sub("(?s)<[^>]*>|&#?\w+;", fixup, s)
+    return re.sub(r"(?s)<[^>]*>|&#?\w+;", fixup, s)
     
 
 def random_string(length=20, alphabet=None):


### PR DESCRIPTION
The regex string contains an invalid \w escape sequence, which causes a warning in modern Python versions. 
(Python does not interpret unknown escape sequences, so \w was passed through unchanged and the regex continued to work correctly.)
This changes the string to a raw string.