### PR TITLE
Remove legacy server-side ballot encryption

### DIFF
--- a/helios/election_url_names.py
+++ b/helios/election_url_names.py
@@ -32,7 +32,6 @@ ELECTION_BBOARD="election@bboard"
 ELECTION_AUDITED_BALLOTS="election@audited-ballots"
 
 ELECTION_GET_RANDOMNESS="election@get-randomness"
-ELECTION_ENCRYPT_BALLOT="election@encrypt-ballot"
 ELECTION_QUESTIONS="election@questions"
 ELECTION_SET_REG="election@set-reg"
 ELECTION_SET_FEATURED="election@set-featured"

--- a/helios/election_urls.py
+++ b/helios/election_urls.py
@@ -64,9 +64,6 @@ urlpatterns = [
     # get randomness
     path('/get-randomness', views.get_randomness, name=names.ELECTION_GET_RANDOMNESS),
 
-    # server-side encryption
-    path('/encrypt-ballot', views.encrypt_ballot, name=names.ELECTION_ENCRYPT_BALLOT),
-
     # construct election
     path('/questions', views.one_election_questions, name=names.ELECTION_QUESTIONS),
     path('/set_reg', views.one_election_set_reg, name=names.ELECTION_SET_REG),

--- a/helios/tests.py
+++ b/helios/tests.py
@@ -649,16 +649,18 @@ class ElectionBlackboxTests(WebTest):
         """
         check_user_logged_in looks for the "you're already logged" message
         """
-        # vote by preparing a ballot via the server-side encryption
-        response = self.app.post("/helios/elections/%s/encrypt-ballot" % election_id,
-                   params={'answers_json': utils.to_json([[1]])})
-        self.assertContains(response, "answers")
+        from helios.workflows import homomorphic
 
-        # parse it as an encrypted vote with randomness, and make sure randomness is there
-        the_ballot = utils.from_json(response.testbody)
+        # get the election and generate an encrypted vote
+        election = models.Election.objects.get(uuid=election_id)
+        answers = [[1]]
+        ev = homomorphic.EncryptedVote.fromElectionAndAnswers(election, answers)
+        the_ballot = ev.ld_object.includeRandomness().toJSONDict()
+
+        # verify randomness is present
         assert 'randomness' in the_ballot['answers'][0], "no randomness"
         assert len(the_ballot['answers'][0]['randomness']) == 2, "not enough randomness"
-        
+
         # parse it as an encrypted vote, and re-serialize it
         ballot = datatypes.LDObject.fromDict(the_ballot, type_hint='legacy/EncryptedVote')
         encrypted_vote = ballot.serialize()

--- a/helios/views.py
+++ b/helios/views.py
@@ -636,17 +636,6 @@ def get_randomness(request, election):
   }
 
 @election_view(frozen=True)
-@return_json
-def encrypt_ballot(request, election):
-  """
-  perform the ballot encryption given answers_json, a JSON'ified list of list of answers
-  (list of list because each question could have a list of answers if more than one.)
-  """
-  answers = utils.from_json(request.POST['answers_json'])
-  ev = homomorphic.EncryptedVote.fromElectionAndAnswers(election, answers)
-  return ev.ld_object.includeRandomness().toJSONDict()
-    
-@election_view(frozen=True)
 def post_audited_ballot(request, election):
   if request.method == "POST":
     raw_vote = request.POST['audited_ballot']

--- a/heliosbooth/vote.html
+++ b/heliosbooth/vote.html
@@ -437,13 +437,6 @@ $(document).ready(function() {
     // we're asynchronous if we have SJCL and Worker
     BOOTH.synchronous = !(USE_SJCL && window.Worker);
 
-    // we do in the browser only if it's asynchronous
-    BigInt.in_browser = !BOOTH.synchronous;
-
-    // set up dummy bigint for fast parsing and serialization
-    if (!BigInt.in_browser)
-      BigInt = BigIntDummy;
-
     BigInt.setup(BOOTH.so_lets_go, BOOTH.nojava);
 });
 
@@ -520,41 +513,14 @@ BOOTH.seal_ballot_raw = function() {
     }
 };
 
-BOOTH.request_ballot_encryption = function() {
-    $.post(BOOTH.election_url + "/encrypt-ballot", {'answers_json': $.toJSON(BOOTH.ballot.answers)}, function(result) {
-      //BOOTH.encrypted_ballot = HELIOS.EncryptedVote.fromJSONObject($.secureEvalJSON(result), BOOTH.election);
-      // rather than deserialize and reserialize, which is inherently slow on browsers
-      // that already need to do network requests, just remove the plaintexts
-
-      BOOTH.encrypted_ballot_with_plaintexts_serialized = result;
-      var ballot_json_obj = $.secureEvalJSON(BOOTH.encrypted_ballot_with_plaintexts_serialized);
-      var answers = ballot_json_obj.answers;
-      for (var i=0; i<answers.length; i++) {
-         delete answers[i]['answer'];
-         delete answers[i]['randomness'];
-      }
-
-      BOOTH.encrypted_ballot_serialized = JSON.stringify(ballot_json_obj);
-
-      window.setTimeout(BOOTH._after_ballot_encryption, 0);
-    });
-};
-
 BOOTH.seal_ballot = function() {
     BOOTH.show_progress('2');
-
-    // if we don't have the ability to do crypto in the browser,
-    // we use the server
-    if (!BigInt.in_browser) {
-      BOOTH.show_encryption_message_before(BOOTH.request_ballot_encryption, true);
-    } else {
-      BOOTH.show_encryption_message_before(BOOTH.seal_ballot_raw, true);
-      $('#percent_done_container').show();
-    }
+    BOOTH.show_encryption_message_before(BOOTH.seal_ballot_raw, true);
+    $('#percent_done_container').show();
 };
 
 BOOTH.audit_ballot = function() {
-    BOOTH.audit_trail = BOOTH.encrypted_ballot_with_plaintexts_serialized || $.toJSON(BOOTH.encrypted_ballot.get_audit_trail());
+    BOOTH.audit_trail = $.toJSON(BOOTH.encrypted_ballot.get_audit_trail());
 
     BOOTH.show($('#audit_div')).processTemplate({'audit_trail' : BOOTH.audit_trail, 'election_url' : BOOTH.election_url});
 };
@@ -578,7 +544,6 @@ BOOTH.cast_ballot = function() {
        BOOTH.encrypted_ballot.clearPlaintexts();
 
     BOOTH.encrypted_ballot_serialized = null;
-    BOOTH.encrypted_ballot_with_plaintexts_serialized = null;
 
     // remove audit trail
     BOOTH.audit_trail = null;


### PR DESCRIPTION
Remove the server-side ballot encryption fallback that was designed for browsers from before 2012 that lacked native cryptographic capabilities.

This workaround allowed browsers to send unencrypted ballots to the server for encryption, which is no longer necessary as all modern browsers support client-side encryption.

Fixes #373