### PR TITLE
Switch from psycopg2 to psycopg2-binary

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ django-webtest>=1.9.11
 gunicorn==22.0.0
 
 dj-database-url==2.2.0
-psycopg2==2.9.10
+psycopg2-binary==2.9.10
 
 celery==5.4.0
 django-picklefield==3.2


### PR DESCRIPTION
psycopg2-binary is a pre-compiled package that doesn't require
PostgreSQL development libraries to be installed during pip install.