### PR TITLE
Replace uuid.uuid1() with uuid.uuid4() to prevent information leakage

### DIFF
--- a/helios/management/commands/load_voter_files.py
+++ b/helios/management/commands/load_voter_files.py
@@ -66,7 +66,7 @@ def process_csv_file(election, f):
 
         # create the voter
         if not voter:
-            voter_uuid = str(uuid.uuid1())
+            voter_uuid = str(uuid.uuid4())
             voter = Voter(uuid=voter_uuid, voter_type='password', voter_id=voter_id, name=name, election=election)
             voter.save()
 

--- a/helios/test.py
+++ b/helios/test.py
@@ -13,7 +13,7 @@ def generate_voters(election, num_voters=1000, start_with=1):
     for v_num in range(start_with, start_with + num_voters):
         user = User(user_type='password', user_id='testuser%s' % v_num, name='Test User %s' % v_num)
         user.save()
-        voter = Voter(uuid=str(uuid.uuid1()), election=election, voter_type=user.user_type, voter_id=user.user_id)
+        voter = Voter(uuid=str(uuid.uuid4()), election=election, voter_type=user.user_type, voter_id=user.user_id)
         voter.save()
 
 

--- a/helios/tests.py
+++ b/helios/tests.py
@@ -436,7 +436,7 @@ class VoterModelTests(TestCase):
         self.election = models.Election.objects.get(short_name='test')
 
     def test_create_password_voter(self):
-        v = models.Voter(uuid = str(uuid.uuid1()), election = self.election, voter_login_id = 'voter_test_1', voter_name = 'Voter Test 1', voter_email='foobar@acme.com')
+        v = models.Voter(uuid = str(uuid.uuid4()), election = self.election, voter_login_id = 'voter_test_1', voter_name = 'Voter Test 1', voter_email='foobar@acme.com')
 
         v.generate_password()
 

--- a/helios/views.py
+++ b/helios/views.py
@@ -204,7 +204,7 @@ def election_new(request):
       
       # is the short name valid
       if utils.urlencode(election_params['short_name']) == election_params['short_name']:
-        election_params['uuid'] = str(uuid.uuid1())
+        election_params['uuid'] = str(uuid.uuid4())
         election_params['cast_url'] = settings.SECURE_URL_HOST + reverse(one_election_cast, args=[election_params['uuid']])
       
         # registration starts closed
@@ -404,7 +404,7 @@ def new_trustee(request, election):
     name = request.POST['name']
     email = request.POST['email']
     
-    trustee = Trustee(uuid = str(uuid.uuid1()), election = election, name=name, email=email)
+    trustee = Trustee(uuid = str(uuid.uuid4()), election = election, name=name, email=email)
     trustee.save()
     return HttpResponseRedirect(settings.SECURE_URL_HOST + reverse(url_names.election.ELECTION_TRUSTEES_VIEW, args=[election.uuid]))
 

--- a/helios_auth/auth_systems/cas.py
+++ b/helios_auth/auth_systems/cas.py
@@ -77,7 +77,7 @@ def get_saml_info(ticket):
        </samlp:Request>
      </soap-env:Body> 
   </soap-env:Envelope>
-""" % (uuid.uuid1(), datetime.datetime.utcnow().isoformat(), ticket)
+""" % (uuid.uuid4(), datetime.datetime.utcnow().isoformat(), ticket)
 
   url = CAS_SAML_VALIDATE_URL % urllib.parse.quote(_get_service_url())
 


### PR DESCRIPTION
UUID v1 contains embedded timestamp and MAC address information that could
be extracted from publicly visible UUIDs. UUID v4 uses cryptographically
random data instead, eliminating this information leakage.

Changed locations:
- Election creation (helios/views.py)
- Manual trustee creation (helios/views.py)
- CAS SAML request ID (helios_auth/auth_systems/cas.py)
- Deprecated voter file loader (helios/management/commands/load_voter_files.py)
- Test helpers (helios/test.py, helios/tests.py)