### PR TITLE
Fix MultipleObjectsReturned error in vote_tinyhash property

### DIFF
--- a/helios/models.py
+++ b/helios/models.py
@@ -991,7 +991,11 @@ class Voter(HeliosModel):
     if not self.vote_hash:
       return None
 
-    return CastVote.objects.get(vote_hash = self.vote_hash).vote_tinyhash
+    # Use filter() and order by cast_at to handle multiple CastVote objects with same vote_hash
+    cast_vote = CastVote.objects.filter(vote_hash=self.vote_hash).order_by('-cast_at').first()
+    if cast_vote:
+      return cast_vote.vote_tinyhash
+    return None
 
   @property
   def election_uuid(self):


### PR DESCRIPTION
Fixes #285

The vote_tinyhash property in the Voter model was using .get() to
retrieve a CastVote object by vote_hash, which caused a
MultipleObjectsReturned error when multiple CastVote objects shared
the same vote_hash.

Changed to use .filter().order_by('-cast_at').first() to properly
handle multiple CastVote objects and return the latest one as
intended by the docstring.

Also added defensive check to return None if no CastVote is found.