### PR TITLE
Remove unused social buttons component

### DIFF
--- a/helios/templates/socialbuttons.html
+++ b/helios/templates/socialbuttons.html
@@ -1,5 +1,0 @@
-<span style="margin: 20px;">
-<a name="fb_share" type="box_count" share_url="{{url}}" href="http://www.facebook.com/sharer.php?t={{text|urlencode}}">Share</a><script src="http://static.ak.fbcdn.net/connect.php/js/FB.Share" type="text/javascript"></script></span>
-
-<a href="http://twitter.com/share" class="twitter-share-button" data-url="{{url}}" data-text="{{text}}" data-count="none" data-via="heliosvoting">Tweet</a><script type="text/javascript" src="http://platform.twitter.com/widgets.js"></script>
-


### PR DESCRIPTION
The template contained deprecated Facebook and Twitter share buttons and was not referenced anywhere in the codebase.