### PR TITLE
Add paragraph formatting to question display

### DIFF
--- a/helios/media/static_templates/question.html
+++ b/helios/media/static_templates/question.html
@@ -187,6 +187,7 @@
   font-size: 1.25em;
   color: #333;
   flex: 1;
+  white-space: pre-line;
 }
 
 .question-number {

--- a/heliosbooth/templates/question.html
+++ b/heliosbooth/templates/question.html
@@ -4,7 +4,7 @@
 
 <p>
 <br /> 
-<b>{$T.question.question}</b>
+<b style="white-space: pre-line;">{$T.question.question}</b>
 <br />
 <span style="font-size: 0.6em;">#{$T.question_num + 1} of {$T.last_question_num + 1} &mdash;
  vote for


### PR DESCRIPTION
Add white-space: pre-line CSS to question text in both the voting booth and admin interface, allowing question authors to use line breaks for basic paragraph formatting.

fixes #348 