### PR TITLE
Remove incorrect DNS and SMTP check flags

### DIFF
--- a/helios/models.py
+++ b/helios/models.py
@@ -792,7 +792,7 @@ class VoterFile(models.Model):
       if len(voter_fields) > 2:
         # but if it's supplied, it will be the 3rd field.
         voter_email = voter_fields[2].strip()
-      if voter_type == "password" and not validate_email(voter_email, check_dns=False, check_smtp=False):
+      if voter_type == "password" and not validate_email(voter_email):
         raise Exception("invalid voter email '%s' for voter id '%s'" % (voter_email, voter_id))
 
       # same thing for voter display name.

--- a/helios/views.py
+++ b/helios/views.py
@@ -1872,7 +1872,7 @@ def optout_form(request):
             'error': 'Email address is required'
         })
     
-    if not validate_email(email, check_dns=False, check_smtp=False):
+    if not validate_email(email):
         return render_template(request, 'optout_form', {
             'action': 'optout',
             'title': 'Opt Out of Helios Emails',
@@ -1980,7 +1980,7 @@ def optin_form(request):
             'error': 'Email address is required'
         })
     
-    if not validate_email(email, check_dns=False, check_smtp=False):
+    if not validate_email(email):
         return render_template(request, 'optout_form', {
             'action': 'optin',
             'title': 'Opt Back Into Helios Emails',


### PR DESCRIPTION
These flags were incorrectly added to validate_email calls. The validate_email library handles DNS/SMTP checking appropriately by default.