### PR TITLE
Fix mobile layout: header and footer now stretch fully

### DIFF
--- a/helios/media/main.css
+++ b/helios/media/main.css
@@ -69,48 +69,60 @@ table.pretty th, td {
 /* Mobile responsive styles */
 @media screen and (max-width: 768px) {
   html, body {
-    width: 100%;
+    max-width: 100vw;
     overflow-x: hidden;
   }
 
   #content {
     position: relative;
-    width: 100%;
-    max-width: 100%;
+    width: 100vw;
+    max-width: 100vw;
     margin-left: 0;
     padding: 10px 15px;
     box-sizing: border-box;
   }
 
   #header {
-    width: 100%;
+    margin-left: -15px;
+    margin-right: -15px;
+    padding-left: 15px;
+    padding-right: 15px;
+    width: calc(100% + 30px);
     box-sizing: border-box;
   }
 
   #footer {
-    width: 100%;
+    margin-left: -15px;
+    margin-right: -15px;
+    padding-left: 15px;
+    padding-right: 15px;
+    width: calc(100% + 30px);
     box-sizing: border-box;
   }
 
+  /* Create a scrollable wrapper for the table */
   table.pretty {
     display: block;
-    margin: 1em 0;
-    font-size: 0.9em;
     width: 100%;
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
+    margin: 1em 0;
+    font-size: 0.9em;
   }
 
   table.pretty thead,
-  table.pretty tbody,
-  table.pretty tr {
-    display: table;
-    width: 100%;
-    table-layout: auto;
+  table.pretty tbody {
+    display: block;
   }
 
-  table.pretty th, table.pretty td {
-    padding: 0.2em;
+  table.pretty tr {
+    display: flex;
+  }
+
+  table.pretty th,
+  table.pretty td {
+    flex: 0 0 auto;
+    padding: 0.2em 0.4em;
     white-space: nowrap;
   }
 }

--- a/helios/media/main.css
+++ b/helios/media/main.css
@@ -66,3 +66,33 @@ table.pretty th, td {
     padding: 0.3em;
 }
 
+/* Mobile responsive styles */
+@media screen and (max-width: 768px) {
+  #content {
+    position: relative;
+    width: 100%;
+    margin-left: 0;
+    padding: 10px 15px;
+    box-sizing: border-box;
+  }
+
+  #footer {
+    width: 100%;
+    box-sizing: border-box;
+  }
+
+  table.pretty {
+    width: 100%;
+    margin: 1em 0;
+    font-size: 0.9em;
+    display: block;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table.pretty th, table.pretty td {
+    padding: 0.2em;
+    white-space: nowrap;
+  }
+}
+

--- a/helios/media/main.css
+++ b/helios/media/main.css
@@ -76,11 +76,10 @@ table.pretty th, td {
   #content {
     position: relative;
     width: 100%;
+    max-width: 100%;
     margin-left: 0;
     padding: 10px 15px;
     box-sizing: border-box;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
   }
 
   #header {
@@ -94,9 +93,20 @@ table.pretty th, td {
   }
 
   table.pretty {
+    display: block;
     margin: 1em 0;
     font-size: 0.9em;
-    min-width: 100%;
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table.pretty thead,
+  table.pretty tbody,
+  table.pretty tr {
+    display: table;
+    width: 100%;
+    table-layout: auto;
   }
 
   table.pretty th, table.pretty td {

--- a/helios/media/main.css
+++ b/helios/media/main.css
@@ -68,11 +68,23 @@ table.pretty th, td {
 
 /* Mobile responsive styles */
 @media screen and (max-width: 768px) {
+  html, body {
+    width: 100%;
+    overflow-x: hidden;
+  }
+
   #content {
     position: relative;
     width: 100%;
     margin-left: 0;
     padding: 10px 15px;
+    box-sizing: border-box;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  #header {
+    width: 100%;
     box-sizing: border-box;
   }
 
@@ -82,12 +94,9 @@ table.pretty th, td {
   }
 
   table.pretty {
-    width: 100%;
     margin: 1em 0;
     font-size: 0.9em;
-    display: block;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
+    min-width: 100%;
   }
 
   table.pretty th, table.pretty td {

--- a/helios/media/main.css
+++ b/helios/media/main.css
@@ -78,50 +78,52 @@ table.pretty th, td {
     width: 100vw;
     max-width: 100vw;
     margin-left: 0;
-    padding: 10px 15px;
+    margin-right: 0;
+    padding: 10px 0;
     box-sizing: border-box;
+    border-left: none;
+    border-right: none;
   }
 
   #header {
-    margin-left: -15px;
-    margin-right: -15px;
     padding-left: 15px;
     padding-right: 15px;
-    width: calc(100% + 30px);
-    box-sizing: border-box;
   }
 
   #footer {
-    margin-left: -15px;
-    margin-right: -15px;
     padding-left: 15px;
     padding-right: 15px;
-    width: calc(100% + 30px);
-    box-sizing: border-box;
   }
 
-  /* Create a scrollable wrapper for the table */
+  #content > *:not(#header):not(#footer) {
+    padding-left: 15px;
+    padding-right: 15px;
+  }
+
+  /* Make table scrollable */
   table.pretty {
     display: block;
-    width: 100%;
+    width: calc(100vw - 30px);
+    margin-left: 15px;
+    margin-right: 15px;
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
-    margin: 1em 0;
     font-size: 0.9em;
   }
 
   table.pretty thead,
   table.pretty tbody {
-    display: block;
+    display: table;
+    width: 100%;
   }
 
   table.pretty tr {
-    display: flex;
+    display: table-row;
   }
 
   table.pretty th,
   table.pretty td {
-    flex: 0 0 auto;
+    display: table-cell;
     padding: 0.2em 0.4em;
     white-space: nowrap;
   }

--- a/helios/media/main.css
+++ b/helios/media/main.css
@@ -73,40 +73,32 @@ table.pretty th, td {
   }
 
   #content {
-    position: static;
+    position: relative;
     width: 100%;
     margin-left: 0;
     padding: 10px 15px;
     box-sizing: border-box;
     border-left: none;
     border-right: none;
-  }
-
-  #header, #footer {
-    width: 100%;
-  }
-
-  /* Wrap table in scrollable container */
-  table.pretty {
-    display: block;
-    width: 100%;
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
   }
 
-  table.pretty thead,
-  table.pretty tbody {
-    display: table;
-    width: auto;
+  #header, #footer {
+    position: sticky;
+    left: 0;
+    width: 100%;
+    background: #eee;
   }
 
-  table.pretty tr {
-    display: table-row;
+  /* Keep table as normal table, let content scroll */
+  table.pretty {
+    width: auto;
+    min-width: 100%;
   }
 
   table.pretty th,
   table.pretty td {
-    display: table-cell;
     white-space: nowrap;
   }
 }

--- a/helios/media/main.css
+++ b/helios/media/main.css
@@ -68,53 +68,36 @@ table.pretty th, td {
 
 /* Mobile responsive styles */
 @media screen and (max-width: 768px) {
-  html, body {
-    max-width: 100vw;
+  body {
     overflow-x: hidden;
   }
 
   #content {
-    position: relative;
-    width: 100vw;
-    max-width: 100vw;
+    position: static;
+    width: 100%;
     margin-left: 0;
-    margin-right: 0;
-    padding: 10px 0;
+    padding: 10px 15px;
     box-sizing: border-box;
     border-left: none;
     border-right: none;
   }
 
-  #header {
-    padding-left: 15px;
-    padding-right: 15px;
+  #header, #footer {
+    width: 100%;
   }
 
-  #footer {
-    padding-left: 15px;
-    padding-right: 15px;
-  }
-
-  #content > *:not(#header):not(#footer) {
-    padding-left: 15px;
-    padding-right: 15px;
-  }
-
-  /* Make table scrollable */
+  /* Wrap table in scrollable container */
   table.pretty {
     display: block;
-    width: calc(100vw - 30px);
-    margin-left: 15px;
-    margin-right: 15px;
+    width: 100%;
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
-    font-size: 0.9em;
   }
 
   table.pretty thead,
   table.pretty tbody {
     display: table;
-    width: 100%;
+    width: auto;
   }
 
   table.pretty tr {
@@ -124,7 +107,6 @@ table.pretty th, td {
   table.pretty th,
   table.pretty td {
     display: table-cell;
-    padding: 0.2em 0.4em;
     white-space: nowrap;
   }
 }

--- a/helios/templates/base.html
+++ b/helios/templates/base.html
@@ -7,6 +7,7 @@
     xml:lang="{% firstof LANGUAGE_CODE 'en' %}"
     lang="{% firstof LANGUAGE_CODE 'en' %}">
   <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}{% endblock %} - Helios</title>
     {% block css %}
       <!--

--- a/helios_auth/media/main.css
+++ b/helios_auth/media/main.css
@@ -57,26 +57,34 @@ body {
 /* Mobile responsive styles */
 @media screen and (max-width: 768px) {
   html, body {
-    width: 100%;
+    max-width: 100vw;
     overflow-x: hidden;
   }
 
   #content {
     position: relative;
-    width: 100%;
-    max-width: 100%;
+    width: 100vw;
+    max-width: 100vw;
     margin-left: 0;
     padding: 10px 15px;
     box-sizing: border-box;
   }
 
   #header {
-    width: 100%;
+    margin-left: -15px;
+    margin-right: -15px;
+    padding-left: 15px;
+    padding-right: 15px;
+    width: calc(100% + 30px);
     box-sizing: border-box;
   }
 
   #footer {
-    width: 100%;
+    margin-left: -15px;
+    margin-right: -15px;
+    padding-left: 15px;
+    padding-right: 15px;
+    width: calc(100% + 30px);
     box-sizing: border-box;
   }
 }

--- a/helios_auth/media/main.css
+++ b/helios_auth/media/main.css
@@ -53,3 +53,19 @@ body {
 #election_info {
   font-size: 16pt;
 }
+
+/* Mobile responsive styles */
+@media screen and (max-width: 768px) {
+  #content {
+    position: relative;
+    width: 100%;
+    margin-left: 0;
+    padding: 10px 15px;
+    box-sizing: border-box;
+  }
+
+  #footer {
+    width: 100%;
+    box-sizing: border-box;
+  }
+}

--- a/helios_auth/media/main.css
+++ b/helios_auth/media/main.css
@@ -64,11 +64,10 @@ body {
   #content {
     position: relative;
     width: 100%;
+    max-width: 100%;
     margin-left: 0;
     padding: 10px 15px;
     box-sizing: border-box;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
   }
 
   #header {

--- a/helios_auth/media/main.css
+++ b/helios_auth/media/main.css
@@ -66,25 +66,25 @@ body {
     width: 100vw;
     max-width: 100vw;
     margin-left: 0;
-    padding: 10px 15px;
+    margin-right: 0;
+    padding: 10px 0;
     box-sizing: border-box;
+    border-left: none;
+    border-right: none;
   }
 
   #header {
-    margin-left: -15px;
-    margin-right: -15px;
     padding-left: 15px;
     padding-right: 15px;
-    width: calc(100% + 30px);
-    box-sizing: border-box;
   }
 
   #footer {
-    margin-left: -15px;
-    margin-right: -15px;
     padding-left: 15px;
     padding-right: 15px;
-    width: calc(100% + 30px);
-    box-sizing: border-box;
+  }
+
+  #content > *:not(#header):not(#footer) {
+    padding-left: 15px;
+    padding-right: 15px;
   }
 }

--- a/helios_auth/media/main.css
+++ b/helios_auth/media/main.css
@@ -56,11 +56,23 @@ body {
 
 /* Mobile responsive styles */
 @media screen and (max-width: 768px) {
+  html, body {
+    width: 100%;
+    overflow-x: hidden;
+  }
+
   #content {
     position: relative;
     width: 100%;
     margin-left: 0;
     padding: 10px 15px;
+    box-sizing: border-box;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  #header {
+    width: 100%;
     box-sizing: border-box;
   }
 

--- a/helios_auth/media/main.css
+++ b/helios_auth/media/main.css
@@ -56,35 +56,21 @@ body {
 
 /* Mobile responsive styles */
 @media screen and (max-width: 768px) {
-  html, body {
-    max-width: 100vw;
+  body {
     overflow-x: hidden;
   }
 
   #content {
-    position: relative;
-    width: 100vw;
-    max-width: 100vw;
+    position: static;
+    width: 100%;
     margin-left: 0;
-    margin-right: 0;
-    padding: 10px 0;
+    padding: 10px 15px;
     box-sizing: border-box;
     border-left: none;
     border-right: none;
   }
 
-  #header {
-    padding-left: 15px;
-    padding-right: 15px;
-  }
-
-  #footer {
-    padding-left: 15px;
-    padding-right: 15px;
-  }
-
-  #content > *:not(#header):not(#footer) {
-    padding-left: 15px;
-    padding-right: 15px;
+  #header, #footer {
+    width: 100%;
   }
 }

--- a/helios_auth/media/main.css
+++ b/helios_auth/media/main.css
@@ -61,16 +61,21 @@ body {
   }
 
   #content {
-    position: static;
+    position: relative;
     width: 100%;
     margin-left: 0;
     padding: 10px 15px;
     box-sizing: border-box;
     border-left: none;
     border-right: none;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
   }
 
   #header, #footer {
+    position: sticky;
+    left: 0;
     width: 100%;
+    background: #eee;
   }
 }

--- a/helios_auth/templates/base.html
+++ b/helios_auth/templates/base.html
@@ -7,6 +7,7 @@
     xml:lang="{% firstof LANGUAGE_CODE 'en' %}"
     lang="{% firstof LANGUAGE_CODE 'en' %}">
   <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}Authentication{% endblock %} - Helios</title>
     {% block css %}
       <!--


### PR DESCRIPTION
Added viewport meta tag and responsive CSS media queries to fix the issue
where header and footer bars don't stretch to full width on mobile devices
when displaying data-heavy pages like the voter table.

Changes:
- Added viewport meta tag to helios and helios_auth base templates
- Added responsive CSS for screens <= 768px width
- On mobile: content and footer use 100% width, removed fixed positioning
- Tables now scroll horizontally on mobile when content is too wide

Fixes header/footer layout issue on mobile devices.