### PR TITLE
add indexes

### DIFF
--- a/helios/migrations/0010_add_query_indexes.py
+++ b/helios/migrations/0010_add_query_indexes.py
@@ -1,0 +1,71 @@
+# Migration to add indexes for frequently queried fields
+# Based on analysis of query patterns across the codebase
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+  dependencies = [
+    ('helios', '0009_add_deleted_at_index'),
+  ]
+
+  operations = [
+    # Priority 1: Voter.uuid - used in get_by_election_and_uuid()
+    migrations.AlterField(
+      model_name='voter',
+      name='uuid',
+      field=models.CharField(max_length=50, db_index=True),
+    ),
+
+    # Priority 1: CastVote compound index on (verified_at, invalidated_at)
+    # Used in num_pending_votes, stats dashboard, verify_cast_votes command
+    migrations.AddIndex(
+      model_name='castvote',
+      index=models.Index(
+        fields=['verified_at', 'invalidated_at'],
+        name='helios_cv_verified_invld_idx',
+      ),
+    ),
+
+    # Priority 1: CastVote.vote_hash - used in ballot verification
+    migrations.AlterField(
+      model_name='castvote',
+      name='vote_hash',
+      field=models.CharField(max_length=100, db_index=True),
+    ),
+
+    # Priority 1: Trustee.uuid - used in get_by_uuid() and get_by_election_and_uuid()
+    migrations.AlterField(
+      model_name='trustee',
+      name='uuid',
+      field=models.CharField(max_length=50, db_index=True),
+    ),
+
+    # Priority 2: Election.featured_p - used in get_featured() for homepage
+    migrations.AlterField(
+      model_name='election',
+      name='featured_p',
+      field=models.BooleanField(default=False, db_index=True),
+    ),
+
+    # Priority 2: ElectionLog compound index on (election_id, at)
+    # Used in get_log() with order_by('-at')
+    migrations.AddIndex(
+      model_name='electionlog',
+      index=models.Index(
+        fields=['election', 'at'],
+        name='helios_eleclog_elec_at_idx',
+      ),
+    ),
+
+    # Priority 3: AuditedBallot compound index on (election_id, vote_hash)
+    # Used in get() for ballot audit lookups
+    migrations.AddIndex(
+      model_name='auditedballot',
+      index=models.Index(
+        fields=['election', 'vote_hash'],
+        name='helios_ab_elec_hash_idx',
+      ),
+    ),
+  ]

--- a/helios/models.py
+++ b/helios/models.py
@@ -85,7 +85,7 @@ class Election(HeliosModel):
   openreg = models.BooleanField(default=False)
 
   # featured election?
-  featured_p = models.BooleanField(default=False)
+  featured_p = models.BooleanField(default=False, db_index=True)
 
   # voter aliases?
   use_voter_aliases = models.BooleanField(default=False)
@@ -788,6 +788,9 @@ class ElectionLog(models.Model):
 
   class Meta:
     app_label = 'helios'
+    indexes = [
+      models.Index(fields=['election', 'at'], name='helios_eleclog_elec_at_idx'),
+    ]
 
 
 class VoterFile(models.Model):
@@ -934,7 +937,7 @@ class Voter(HeliosModel):
   #voter_type = models.CharField(max_length = 100)
   #voter_id = models.CharField(max_length = 100)
 
-  uuid = models.CharField(max_length = 50)
+  uuid = models.CharField(max_length=50, db_index=True)
 
   # for users of type password, no user object is created
   # but a dynamic user object is created automatically
@@ -1139,7 +1142,7 @@ class CastVote(HeliosModel):
   vote = LDObjectField(type_hint = 'legacy/EncryptedVote')
 
   # cache the hash of the vote
-  vote_hash = models.CharField(max_length=100)
+  vote_hash = models.CharField(max_length=100, db_index=True)
 
   # a tiny version of the hash to enable short URLs
   vote_tinyhash = models.CharField(max_length=50, null=True, unique=True)
@@ -1158,7 +1161,10 @@ class CastVote(HeliosModel):
   cast_ip = models.GenericIPAddressField(null=True)
 
   class Meta:
-      app_label = 'helios'
+    app_label = 'helios'
+    indexes = [
+      models.Index(fields=['verified_at', 'invalidated_at'], name='helios_cv_verified_invld_idx'),
+    ]
 
   @property
   def datatype(self):
@@ -1250,6 +1256,9 @@ class AuditedBallot(models.Model):
 
   class Meta:
     app_label = 'helios'
+    indexes = [
+      models.Index(fields=['election', 'vote_hash'], name='helios_ab_elec_hash_idx'),
+    ]
 
   @classmethod
   def get(cls, election, vote_hash):
@@ -1272,7 +1281,7 @@ class AuditedBallot(models.Model):
 class Trustee(HeliosModel):
   election = models.ForeignKey(Election, on_delete=models.CASCADE)
 
-  uuid = models.CharField(max_length=50)
+  uuid = models.CharField(max_length=50, db_index=True)
   name = models.CharField(max_length=200)
   email = models.EmailField()
   secret = models.CharField(max_length=100)


### PR DESCRIPTION
Based on analysis of query patterns across the codebase, add indexes to improve performance for common lookups:

Priority 1 (Critical):
- Voter.uuid: Used in get_by_election_and_uuid() for voter detail pages
- CastVote(verified_at, invalidated_at): Used in num_pending_votes, admin dashboard, and verify_cast_votes background task
- CastVote.vote_hash: Used in ballot verification lookups
- Trustee.uuid: Used in trustee dashboard access

Priority 2 (High):
- Election.featured_p: Used in get_featured() for homepage display
- ElectionLog(election, at): Used in audit log display with ordering

Priority 3 (Medium):
- AuditedBallot(election, vote_hash): Used in ballot audit lookups