### PR TITLE
Fix biased sampling in random_mpz_lt

### DIFF
--- a/helios/crypto/utils.py
+++ b/helios/crypto/utils.py
@@ -2,7 +2,6 @@
 Crypto Utils
 """
 import base64
-import math
 
 from Crypto.Hash import SHA256
 from Crypto.Random.random import StrongRandom
@@ -11,7 +10,16 @@ random = StrongRandom()
 
 
 def random_mpz_lt(maximum, strong_random=random):
-    n_bits = int(math.floor(math.log(maximum, 2)))
+    """
+    Uniformly sample an integer in [0, maximum).
+
+    n_bits must be the exact bit length of maximum, not floor(log2(maximum)):
+    the latter is one too small for every maximum that isn't a power of two,
+    which caps the output at 2^(n_bits) - 1 < maximum. The rejection loop below
+    then never fires and the top slice of the range is never sampled (5.6% of
+    the range for the default 256-bit q), biasing every exponent drawn here.
+    """
+    n_bits = maximum.bit_length()
     res = strong_random.getrandbits(n_bits)
     while res >= maximum:
         res = strong_random.getrandbits(n_bits)

--- a/helios/crypto/utils.py
+++ b/helios/crypto/utils.py
@@ -13,11 +13,13 @@ def random_mpz_lt(maximum, strong_random=random):
     """
     Uniformly sample an integer in [0, maximum).
 
-    n_bits must be the exact bit length of maximum, not floor(log2(maximum)):
-    the latter is one too small for every maximum that isn't a power of two,
-    which caps the output at 2^(n_bits) - 1 < maximum. The rejection loop below
-    then never fires and the top slice of the range is never sampled (5.6% of
-    the range for the default 256-bit q), biasing every exponent drawn here.
+    Sizing the draw with maximum.bit_length() is what leaves the rejection loop
+    below any work to do. This used to size it with floor(log2(maximum)), which
+    is one bit short for every maximum that isn't a power of two: getrandbits
+    could then only return values below 2^(bit_length - 1), already less than
+    maximum. Nothing was ever rejected, and the top slice of [0, maximum) was
+    never sampled -- 5.6% of the range for the default 256-bit q -- biasing
+    every exponent drawn here.
 
     Raises ValueError for a non-positive maximum, which names no valid result:
     the rejection loop would otherwise spin forever, since every draw is >= 0.

--- a/helios/crypto/utils.py
+++ b/helios/crypto/utils.py
@@ -18,7 +18,13 @@ def random_mpz_lt(maximum, strong_random=random):
     which caps the output at 2^(n_bits) - 1 < maximum. The rejection loop below
     then never fires and the top slice of the range is never sampled (5.6% of
     the range for the default 256-bit q), biasing every exponent drawn here.
+
+    Raises ValueError for a non-positive maximum, which names no valid result:
+    the rejection loop would otherwise spin forever, since every draw is >= 0.
     """
+    if maximum <= 0:
+        raise ValueError("maximum must be positive, got %r" % (maximum,))
+
     n_bits = maximum.bit_length()
     res = strong_random.getrandbits(n_bits)
     while res >= maximum:

--- a/helios/tests.py
+++ b/helios/tests.py
@@ -37,8 +37,16 @@ class RandomMpzLtTests(TestCase):
     # the q of the default Helios group, see helios.views.ELGAMAL_PARAMS
     Q = 61329566248342901292543872769978950870633559608669337131139375508370458778917
 
-    class FakeRandom(object):
-        """Records the bit counts requested, and replays a canned sequence."""
+    class ScriptedRandom(object):
+        """
+        Replays a canned sequence of draws and records the bit counts asked for.
+
+        getrandbits is honest about its width -- each value is masked to the
+        number of bits requested, exactly as a real generator would -- so a test
+        can tell a 255-bit draw from a 256-bit one by what comes back. Running
+        the sequence dry raises rather than blocking, so a regression that stops
+        the rejection loop from terminating fails the test instead of hanging it.
+        """
 
         def __init__(self, values):
             self.values = list(values)
@@ -46,47 +54,51 @@ class RandomMpzLtTests(TestCase):
 
         def getrandbits(self, n_bits):
             self.requested_bits.append(n_bits)
-            return self.values.pop(0)
+            if not self.values:
+                raise AssertionError(
+                    "random_mpz_lt drew more times than the test scripted; "
+                    "the rejection loop is not terminating")
+            return self.values.pop(0) & ((1 << n_bits) - 1)
 
-    def test_requests_the_full_bit_length(self):
-        """Sampling must draw maximum.bit_length() bits, not floor(log2(maximum))."""
-        fake = self.FakeRandom([0])
-        crypto_utils.random_mpz_lt(self.Q, strong_random=fake)
-        self.assertEqual(fake.requested_bits, [256])
+    def test_samples_the_top_of_the_range(self):
+        """
+        Regression test: sizing the draw with floor(log2(q)) asked for 255 bits
+        and capped the output at 2^255 - 1, so the top 5.6% of [0, q) was never
+        sampled. That made the simulated branch of a disjunctive proof
+        distinguishable from the real one, which leaks the plaintext.
+
+        q - 1 lies in that top slice, so it survives a 256-bit draw but loses
+        its high bit to a 255-bit one -- no real randomness needed to tell the
+        two apart.
+        """
         self.assertEqual(self.Q.bit_length(), 256)
-
-    def test_rejects_values_at_or_above_maximum(self):
-        """Draws >= maximum are discarded and redrawn, keeping the result in range."""
-        fake = self.FakeRandom([self.Q, self.Q + 1, self.Q - 1])
-        result = crypto_utils.random_mpz_lt(self.Q, strong_random=fake)
+        scripted = self.ScriptedRandom([self.Q - 1])
+        result = crypto_utils.random_mpz_lt(self.Q, strong_random=scripted)
+        self.assertEqual(scripted.requested_bits, [256])
         self.assertEqual(result, self.Q - 1)
-        self.assertEqual(fake.requested_bits, [256, 256, 256])
+        self.assertGreaterEqual(result, 1 << 255)
 
-    def test_reaches_the_top_of_the_range(self):
+    def test_redraws_values_at_or_above_maximum(self):
+        """Draws >= maximum are discarded and redrawn, keeping the result in range."""
+        scripted = self.ScriptedRandom([self.Q, self.Q + 1, self.Q - 1])
+        result = crypto_utils.random_mpz_lt(self.Q, strong_random=scripted)
+        self.assertEqual(result, self.Q - 1)
+        self.assertEqual(scripted.requested_bits, [256, 256, 256])
+
+    def test_rejects_non_positive_maximum(self):
         """
-        Regression test: with floor(log2(q)) bits the output was capped at
-        2^255 - 1, so the top 5.6% of [0, q) was never sampled. That made the
-        simulated branch of a disjunctive proof distinguishable from the real
-        one, which leaks the plaintext.
+        No integer satisfies 0 <= res < maximum when maximum <= 0, so the
+        rejection loop would spin forever. Fail loudly instead, as the previous
+        math.log implementation did.
         """
-        threshold = 1 << 255
-        self.assertLess(threshold, self.Q)
-        # each draw clears the threshold with probability ~5.6%, so 500 draws
-        # miss with probability ~3e-13
-        samples = [crypto_utils.random_mpz_lt(self.Q) for _ in range(500)]
-        self.assertTrue(any(sample >= threshold for sample in samples))
-        self.assertTrue(all(0 <= sample < self.Q for sample in samples))
-
-    def test_covers_every_value_of_a_small_range(self):
-        """A small maximum yields every value below it, and never maximum itself."""
-        samples = set(crypto_utils.random_mpz_lt(3) for _ in range(200))
-        self.assertEqual(samples, {0, 1, 2})
-
-    def test_power_of_two_maximum(self):
-        """An exact power of two stays in range (the old floor(log2()) edge case)."""
-        samples = [crypto_utils.random_mpz_lt(256) for _ in range(200)]
-        self.assertTrue(all(0 <= sample < 256 for sample in samples))
-        self.assertTrue(any(sample >= 128 for sample in samples))
+        for maximum in (0, -1, -self.Q):
+            with self.subTest(maximum=maximum):
+                # a scripted generator turns a regression here into a failure
+                # rather than a hang
+                scripted = self.ScriptedRandom([0, 0, 0])
+                with self.assertRaises(ValueError):
+                    crypto_utils.random_mpz_lt(maximum, strong_random=scripted)
+                self.assertEqual(scripted.requested_bits, [])
 
 
 class ElectionModelTests(TestCase):

--- a/helios/tests.py
+++ b/helios/tests.py
@@ -34,8 +34,8 @@ class RandomMpzLtTests(TestCase):
     from [0, maximum) -- every exponent in the system is drawn through it.
     """
 
-    # the q of the default Helios group, see helios.views.ELGAMAL_PARAMS
-    Q = 61329566248342901292543872769978950870633559608669337131139375508370458778917
+    # the exponent modulus every real draw is bounded by
+    Q = views.ELGAMAL_PARAMS.q
 
     class ScriptedRandom(object):
         """
@@ -62,28 +62,34 @@ class RandomMpzLtTests(TestCase):
 
     def test_samples_the_top_of_the_range(self):
         """
-        Regression test: sizing the draw with floor(log2(q)) asked for 255 bits
-        and capped the output at 2^255 - 1, so the top 5.6% of [0, q) was never
-        sampled. That made the simulated branch of a disjunctive proof
-        distinguishable from the real one, which leaks the plaintext.
+        Regression test: sizing the draw with floor(log2(q)) asked for one bit
+        too few and capped the output below 2^(bit_length - 1), so the top 5.6%
+        of [0, q) was never sampled. That made the simulated branch of a
+        disjunctive proof distinguishable from the real one, which leaks the
+        plaintext.
 
-        q - 1 lies in that top slice, so it survives a 256-bit draw but loses
-        its high bit to a 255-bit one -- no real randomness needed to tell the
-        two apart.
+        q - 1 lies in that top slice, so it survives a full-width draw but loses
+        its high bit to a one-bit-short one -- enough to tell the two sizings
+        apart without any real randomness.
         """
-        self.assertEqual(self.Q.bit_length(), 256)
+        n_bits = self.Q.bit_length()
+        top_slice = 1 << (n_bits - 1)
+        # q is prime, hence not a power of two, so q - 1 is inside the slice
+        self.assertGreater(self.Q - 1, top_slice)
+
         scripted = self.ScriptedRandom([self.Q - 1])
         result = crypto_utils.random_mpz_lt(self.Q, strong_random=scripted)
-        self.assertEqual(scripted.requested_bits, [256])
+        self.assertEqual(scripted.requested_bits, [n_bits])
         self.assertEqual(result, self.Q - 1)
-        self.assertGreaterEqual(result, 1 << 255)
+        self.assertGreaterEqual(result, top_slice)
 
     def test_redraws_values_at_or_above_maximum(self):
         """Draws >= maximum are discarded and redrawn, keeping the result in range."""
+        n_bits = self.Q.bit_length()
         scripted = self.ScriptedRandom([self.Q, self.Q + 1, self.Q - 1])
         result = crypto_utils.random_mpz_lt(self.Q, strong_random=scripted)
         self.assertEqual(result, self.Q - 1)
-        self.assertEqual(scripted.requested_bits, [256, 256, 256])
+        self.assertEqual(scripted.requested_bits, [n_bits] * 3)
 
     def test_rejects_non_positive_maximum(self):
         """

--- a/helios/tests.py
+++ b/helios/tests.py
@@ -23,8 +23,70 @@ import helios.views as views
 from helios import tasks
 from helios.crypto import algs, electionalgs
 from helios.crypto import elgamal as crypto_elgamal
+from helios.crypto import utils as crypto_utils
 from helios.workflows import homomorphic
 from helios_auth import models as auth_models
+
+
+class RandomMpzLtTests(TestCase):
+    """
+    Tests for helios.crypto.utils.random_mpz_lt, which must sample uniformly
+    from [0, maximum) -- every exponent in the system is drawn through it.
+    """
+
+    # the q of the default Helios group, see helios.views.ELGAMAL_PARAMS
+    Q = 61329566248342901292543872769978950870633559608669337131139375508370458778917
+
+    class FakeRandom(object):
+        """Records the bit counts requested, and replays a canned sequence."""
+
+        def __init__(self, values):
+            self.values = list(values)
+            self.requested_bits = []
+
+        def getrandbits(self, n_bits):
+            self.requested_bits.append(n_bits)
+            return self.values.pop(0)
+
+    def test_requests_the_full_bit_length(self):
+        """Sampling must draw maximum.bit_length() bits, not floor(log2(maximum))."""
+        fake = self.FakeRandom([0])
+        crypto_utils.random_mpz_lt(self.Q, strong_random=fake)
+        self.assertEqual(fake.requested_bits, [256])
+        self.assertEqual(self.Q.bit_length(), 256)
+
+    def test_rejects_values_at_or_above_maximum(self):
+        """Draws >= maximum are discarded and redrawn, keeping the result in range."""
+        fake = self.FakeRandom([self.Q, self.Q + 1, self.Q - 1])
+        result = crypto_utils.random_mpz_lt(self.Q, strong_random=fake)
+        self.assertEqual(result, self.Q - 1)
+        self.assertEqual(fake.requested_bits, [256, 256, 256])
+
+    def test_reaches_the_top_of_the_range(self):
+        """
+        Regression test: with floor(log2(q)) bits the output was capped at
+        2^255 - 1, so the top 5.6% of [0, q) was never sampled. That made the
+        simulated branch of a disjunctive proof distinguishable from the real
+        one, which leaks the plaintext.
+        """
+        threshold = 1 << 255
+        self.assertLess(threshold, self.Q)
+        # each draw clears the threshold with probability ~5.6%, so 500 draws
+        # miss with probability ~3e-13
+        samples = [crypto_utils.random_mpz_lt(self.Q) for _ in range(500)]
+        self.assertTrue(any(sample >= threshold for sample in samples))
+        self.assertTrue(all(0 <= sample < self.Q for sample in samples))
+
+    def test_covers_every_value_of_a_small_range(self):
+        """A small maximum yields every value below it, and never maximum itself."""
+        samples = set(crypto_utils.random_mpz_lt(3) for _ in range(200))
+        self.assertEqual(samples, {0, 1, 2})
+
+    def test_power_of_two_maximum(self):
+        """An exact power of two stays in range (the old floor(log2()) edge case)."""
+        samples = [crypto_utils.random_mpz_lt(256) for _ in range(200)]
+        self.assertTrue(all(0 <= sample < 256 for sample in samples))
+        self.assertTrue(any(sample >= 128 for sample in samples))
 
 
 class ElectionModelTests(TestCase):


### PR DESCRIPTION
## The bug

`random_mpz_lt` sized its draw with `int(math.floor(math.log(maximum, 2)))`, which is one bit short of `maximum.bit_length()` for every `maximum` that isn't an exact power of two:

```python
n_bits = int(math.floor(math.log(maximum, 2)))
res = strong_random.getrandbits(n_bits)
while res >= maximum:          # dead code
    res = strong_random.getrandbits(n_bits)
```

`getrandbits(n_bits)` therefore always returned a value below `2^n_bits < maximum`, the rejection loop never fired, and the top slice of `[0, maximum)` was never sampled.

For the default Helios group `q` is 256 bits but `floor(log2(q))` is 255, so exponents were drawn uniformly from `[0, 2^255)` instead of `[0, q)`. **5.60% of the range was unreachable** (0.083 bits of entropy).

## Impact

Worst in the disjunctive encryption proofs (`elgamal.py`). A simulated branch takes both its `challenge` and its `response` straight from `random_mpz_lt`, so both are below `2^255`. The real branch's challenge is `(disjunctive_challenge - Σ simulated challenges) % q` and its response is `(w + r*c) % q`, both covering the full `[0, q)`. So **any published proof with a challenge or response at or above `2^255` identifies that branch as the real one and reveals the plaintext** — roughly a 10.9% chance per encrypted answer for a 0/1 proof.

Trustee secret keys (`generate_keypair`) and the blinding values `w` in decryption proofs and `prove_sk` were biased by the same 0.083 bits. That's the classic biased-nonce shape, but recovering `x` would need far more proofs than an election produces, so it's real but not practically exploitable.

**Ballots cast through the booth are unaffected.** `heliosbooth/js/jscrypto/random.js` uses `max.bitLength()` and over-draws 64 bits before reducing mod `max` — residual bias ~2⁻⁶⁴. I confirmed this by running the actual booth files in Node: over 20,000 samples with the production `q`, 1156 landed in `[2^255, q)` against 1119.7 expected, with none out of range. So this is a Python-side bug only.

## The fix

Use `maximum.bit_length()`, which is exact — it also avoids the float-precision risk of `math.log` on 2048-bit integers — and lets the rejection loop do its job. Fewer than two iterations expected; ~1.06 for the default `q`.

A non-positive `maximum` names no valid result, and with `bit_length()` the rejection loop would spin on it forever (`(0).bit_length()` is `0`, `getrandbits(0)` returns `0`, `0 >= 0`). The `math.log` version raised `ValueError` there, so that is now restored with an explicit guard.

## Tests

`RandomMpzLtTests` in `helios/tests.py`, three tests, each catching something the others don't:

| Test | Catches |
| --- | --- |
| `test_samples_the_top_of_the_range` | the bit sizing, and the top slice the old code could never reach |
| `test_redraws_values_at_or_above_maximum` | the rejection loop |
| `test_rejects_non_positive_maximum` | the non-positive guard |

All three are deterministic — they drive `random_mpz_lt` through its injectable RNG rather than sampling real randomness, so nothing here can flake. The stub masks each value to the width requested, exactly as a real `getrandbits` does, which is what makes a 255-bit draw distinguishable from a 256-bit one:

```python
return self.values.pop(0) & ((1 << n_bits) - 1)
```

The stub also raises when its scripted sequence runs dry, so a regression that stops the rejection loop from terminating fails in about a second instead of hanging CI.

Verified by falsification against two broken variants: the original `floor(log2())` implementation fails 2 of 3, and a `bit_length()` version without the guard fails 3 of 3.

Full suite: **206 tests, all passing** (`uv run python -Wall manage.py test -v 2 --settings=settings_ci`), rebased onto `master` at b6e36e4.

## Follow-up not included here

`heliosverifier/js/jscrypto/random.js` is a stale, diverged copy of the booth's version that drops the extra 64 bits and calls `BigInt._from_java_object`, which is undefined on the `USE_SJCL` path. It's dead code — `verify.html` never generates randomness — but worth syncing or deleting separately so it isn't copied forward.