### PR TITLE
Check ElGamal group membership when verifying cast ballots

### DIFF
--- a/helios/crypto/algs.py
+++ b/helios/crypto/algs.py
@@ -637,8 +637,8 @@ class EGZKProof(object):
         Verify a DH tuple proof
         """
         # check that A, B are in the correct group
-        if not (pow(self.commitment['A'], self.pk.q, self.pk.p) == 1
-                and pow(self.commitment['B'], self.pk.q, self.pk.p) == 1):
+        if not (pow(self.commitment['A'], q, p) == 1
+                and pow(self.commitment['B'], q, p) == 1):
             return False
 
         # check that little_g^response = A * big_g^challenge

--- a/helios/crypto/elgamal.py
+++ b/helios/crypto/elgamal.py
@@ -369,7 +369,12 @@ class Ciphertext:
       
       Proof contains commitment = {A, B}, challenge, response
       """
-      
+
+      # check that A, B are in the correct group
+      if not (pow(proof.commitment['A'], self.pk.q, self.pk.p) == 1
+              and pow(proof.commitment['B'], self.pk.q, self.pk.p) == 1):
+        return False
+
       # check that g^response = A * alpha^challenge
       first_check = (pow(self.pk.g, proof.response, self.pk.p) == ((pow(self.alpha, proof.challenge, self.pk.p) * proof.commitment['A']) % self.pk.p))
       
@@ -425,6 +430,25 @@ class Ciphertext:
         
       return running_decryption
 
+    def check_group_membership(self, pk):
+      """
+      checks to see if an ElGamal element belongs to the group in the pk
+      """
+      if not (1 < self.alpha < pk.p - 1):
+        return False
+
+      elif not (1 < self.beta < pk.p - 1):
+        return False
+
+      elif pow(self.alpha, pk.q, pk.p) != 1:
+        return False
+
+      elif pow(self.beta, pk.q, pk.p) != 1:
+        return False
+
+      else:
+        return True
+
     def to_string(self):
         return "%s,%s" % (self.alpha, self.beta)
     
@@ -472,6 +496,11 @@ class ZKProof(object):
     """
     Verify a DH tuple proof
     """
+    # check that A, B are in the correct group
+    if not (pow(self.commitment['A'], q, p) == 1
+            and pow(self.commitment['B'], q, p) == 1):
+      return False
+
     # check that little_g^response = A * big_g^challenge
     first_check = (pow(little_g, self.response, p) == ((pow(big_g, self.challenge, p) * self.commitment['A']) % p))
     

--- a/helios/tests.py
+++ b/helios/tests.py
@@ -508,51 +508,41 @@ class CastVoteModelTests(TestCase):
     def test_cast_vote(self):
         pass
 
-class BallotGroupMembershipTestsMixin(object):
+class BallotGroupMembershipTests(TestCase):
     """
-    Ballot verification must reject ciphertext elements that do not live in the
-    order-q subgroup. The Helios parameters use a 2048-bit p with a 256-bit q, so
-    p-1 has a large cofactor and elements of small order do exist; a proof of
-    knowledge alone does not pin alpha and beta down to the intended subgroup.
+    A cast ballot's ciphertext elements must lie in the order-q subgroup named by
+    the election public key. The Helios parameters use a 2048-bit p with a 256-bit
+    q, so p-1 has a large cofactor and elements of small order do exist; the proof
+    of knowledge on its own does not confine alpha and beta to the subgroup.
 
-    There are two ElGamal implementations in the tree, and only one of them is
-    reachable from a cast ballot, so every case here runs against both.
+    A cast ballot deserializes into crypto.elgamal by way of datatypes.legacy, so
+    that is the implementation exercised here.
     """
     allow_database_queries = False
 
-    # filled in by the concrete subclasses
-    public_key_class = None
-    secret_key_class = None
-    ciphertext_class = None
-    proof_class = None
-    disjunctive_proof_class = None
-    secret_key_public_key_attribute = 'pk'
+    # fixed so that a failure reproduces exactly; no assertion depends on the
+    # particular values drawn
+    SEED = 20260815
 
     def setUp(self):
         params = views.ELGAMAL_PARAMS
         self.p, self.q, self.g = params.p, params.q, params.g
+        self.rand = stdlib_random.Random(self.SEED)
 
-        secret = stdlib_random.randrange(2, self.q)
-        self.pk = self.public_key_class()
+        self.pk = crypto_elgamal.PublicKey()
         self.pk.p, self.pk.q, self.pk.g = self.p, self.q, self.g
-        self.pk.y = pow(self.g, secret, self.p)
-
-        self.sk = self.secret_key_class()
-        self.sk.x = secret
-        setattr(self.sk, self.secret_key_public_key_attribute, self.pk)
+        self.pk.y = pow(self.g, self.rand.randrange(2, self.q), self.p)
 
         self.plaintexts = homomorphic.EncryptedAnswer.generate_plaintexts(self.pk)
 
-        # p-1 has order 2, so it is a witness that p is not a safe prime
+        # p-1 has order 2, and is a witness that p is not a safe prime
         self.small_order_element = self.p - 1
-        self.assertEqual(pow(self.small_order_element, 2, self.p), 1)
-        self.assertNotEqual(pow(self.small_order_element, self.q, self.p), 1)
 
     def encrypt(self, exponent, randomness, outside_subgroup=False):
         """
         encrypt g^exponent, optionally pushing alpha out of the order-q subgroup
         """
-        ciphertext = self.ciphertext_class()
+        ciphertext = crypto_elgamal.Ciphertext()
         ciphertext.pk = self.pk
         ciphertext.alpha = pow(self.g, randomness, self.p)
         if outside_subgroup:
@@ -560,135 +550,126 @@ class BallotGroupMembershipTestsMixin(object):
         ciphertext.beta = (pow(self.pk.y, randomness, self.p) * pow(self.g, exponent, self.p)) % self.p
         return ciphertext
 
+    def simulate_proof(self, ciphertext, plaintext, challenge):
+        """
+        the textbook simulation, spelled out so that the whole forgery is driven by
+        this test's seeded randomness rather than the process CSPRNG
+        """
+        proof = crypto_elgamal.ZKProof()
+        proof.challenge = challenge
+        proof.response = self.rand.randrange(self.q)
+
+        beta_over_m = (ciphertext.beta * pow(plaintext.m, -1, self.p)) % self.p
+        proof.commitment = {
+            'A': (pow(self.g, proof.response, self.p)
+                  * pow(pow(ciphertext.alpha, challenge, self.p), -1, self.p)) % self.p,
+            'B': (pow(self.pk.y, proof.response, self.p)
+                  * pow(pow(beta_over_m, challenge, self.p), -1, self.p)) % self.p,
+        }
+        return proof
+
     def forge_disjunctive_proof(self, ciphertext, real_index, randomness):
         """
-        Build a disjunctive proof for a ciphertext whose alpha carries a factor of
-        order 2. Every stored challenge is ground to be even, so that factor raised
-        to the challenge is 1 and drops out of each verification equation. Only a
-        couple of attempts per proof are needed, which is precisely why the subgroup
-        check cannot be left to the proof itself.
+        A disjunctive proof for a ciphertext whose alpha carries a factor of order 2.
+        Every stored challenge is ground to be even, so that factor raised to the
+        challenge is 1 and cancels out of each verification equation. It takes a
+        couple of attempts, which is why the subgroup check cannot be left to the
+        proof itself.
         """
-        for _ in range(200):
-            proofs = [None] * len(self.plaintexts)
-            for index in range(len(self.plaintexts)):
-                if index != real_index:
-                    even_challenge = 2 * stdlib_random.randrange(1, self.q // 2)
-                    proofs[index] = ciphertext.simulate_encryption_proof(
-                        self.plaintexts[index], challenge=even_challenge)
+        for _ in range(100):
+            proofs = [
+                None if index == real_index else self.simulate_proof(
+                    ciphertext, self.plaintexts[index], 2 * self.rand.randrange(1, self.q // 2))
+                for index in range(len(self.plaintexts))
+            ]
 
-            commitment_randomness = stdlib_random.randrange(self.q)
-            real_proof = self.proof_class()
+            commitment_randomness = self.rand.randrange(self.q)
+            real_proof = crypto_elgamal.ZKProof()
             real_proof.commitment = {
                 'A': pow(self.g, commitment_randomness, self.p),
                 'B': pow(self.pk.y, commitment_randomness, self.p),
             }
             proofs[real_index] = real_proof
 
-            overall = algs.EG_disjunctive_challenge_generator([p.commitment for p in proofs])
-            simulated_sum = sum(proofs[i].challenge for i in range(len(proofs)) if i != real_index)
-            challenge = (overall - simulated_sum) % self.q
-
+            challenge = (algs.EG_disjunctive_challenge_generator([p.commitment for p in proofs])
+                         - sum(p.challenge for i, p in enumerate(proofs) if i != real_index)) % self.q
             if challenge % 2:
                 continue
 
             real_proof.challenge = challenge
             real_proof.response = (commitment_randomness + randomness * challenge) % self.q
-            return self.disjunctive_proof_class(proofs)
+            return crypto_elgamal.ZKDisjunctiveProof(proofs)
 
         self.fail("could not grind an even challenge")
 
-    def build_answer(self, outside_subgroup):
+    def build_answer(self, forged):
         """
-        a single-question, two-answer ballot voting for the first answer
+        a single question, two answers, voting for the first one
         """
-        randomness = [stdlib_random.randrange(self.q) for _ in range(2)]
-        choices = [
-            self.encrypt(1, randomness[0], outside_subgroup=outside_subgroup),
-            self.encrypt(0, randomness[1]),
-        ]
+        randomness = [self.rand.randrange(self.q) for _ in range(2)]
+        choices = [self.encrypt(1, randomness[0], outside_subgroup=forged),
+                   self.encrypt(0, randomness[1])]
+
+        if forged:
+            prove = self.forge_disjunctive_proof
+        else:
+            def prove(ciphertext, real_index, r):
+                return ciphertext.generate_disjunctive_encryption_proof(
+                    self.plaintexts, real_index, r, algs.EG_disjunctive_challenge_generator)
 
         answer = homomorphic.EncryptedAnswer()
         answer.choices = choices
-
-        if outside_subgroup:
-            answer.individual_proofs = [
-                self.forge_disjunctive_proof(choices[0], 1, randomness[0]),
-                self.forge_disjunctive_proof(choices[1], 0, randomness[1]),
-            ]
-            answer.overall_proof = self.forge_disjunctive_proof(
-                choices[0] * choices[1], 1, (randomness[0] + randomness[1]) % self.q)
-        else:
-            answer.individual_proofs = [
-                choices[0].generate_disjunctive_encryption_proof(
-                    self.plaintexts, 1, randomness[0], algs.EG_disjunctive_challenge_generator),
-                choices[1].generate_disjunctive_encryption_proof(
-                    self.plaintexts, 0, randomness[1], algs.EG_disjunctive_challenge_generator),
-            ]
-            answer.overall_proof = (choices[0] * choices[1]).generate_disjunctive_encryption_proof(
-                self.plaintexts, 1, (randomness[0] + randomness[1]) % self.q,
-                algs.EG_disjunctive_challenge_generator)
-
+        answer.individual_proofs = [prove(choices[0], 1, randomness[0]),
+                                    prove(choices[1], 0, randomness[1])]
+        answer.overall_proof = prove(choices[0] * choices[1], 1,
+                                     (randomness[0] + randomness[1]) % self.q)
         return answer
 
     def test_well_formed_answer_verifies(self):
-        answer = self.build_answer(outside_subgroup=False)
-        self.assertTrue(answer.verify(self.pk, min=0, max=1))
+        self.assertTrue(self.build_answer(forged=False).verify(self.pk, min=0, max=1))
 
     def test_answer_outside_subgroup_is_rejected(self):
-        answer = self.build_answer(outside_subgroup=True)
+        answer = self.build_answer(forged=True)
 
-        # the forged ballot is well formed apart from the subgroup violation:
-        # every proof equation still holds
+        # the ballot is well formed apart from the subgroup violation: every proof
+        # equation still holds, so only the membership check can catch it
         self.assertNotEqual(pow(answer.choices[0].alpha, self.q, self.p), 1)
         for choice_num, choice in enumerate(answer.choices):
-            choice.pk = self.pk
             self.assertTrue(choice.verify_disjunctive_encryption_proof(
                 self.plaintexts, answer.individual_proofs[choice_num],
                 algs.EG_disjunctive_challenge_generator))
 
         self.assertFalse(answer.verify(self.pk, min=0, max=1))
 
-    def test_check_group_membership_rejects_small_order_factor(self):
-        ciphertext = self.encrypt(1, stdlib_random.randrange(self.q), outside_subgroup=True)
-        self.assertFalse(ciphertext.check_group_membership(self.pk))
-
-    def test_decryption_factor_proof_verifies(self):
-        """
-        the DH tuple proof is reached when a trustee uploads its decryption; it must
-        use the p and q it is handed rather than attributes it does not carry
-        """
-        randomness = stdlib_random.randrange(self.q)
-        ciphertext = self.encrypt(1, randomness)
-
-        factor, proof = self.sk.decryption_factor_and_proof(ciphertext)
-
-        self.assertTrue(proof.verify(
-            self.pk.g, ciphertext.alpha, self.pk.y, factor, self.pk.p, self.pk.q,
-            algs.EG_fiatshamir_challenge_generator))
-
-
-class AlgsBallotGroupMembershipTests(BallotGroupMembershipTestsMixin, TestCase):
-    public_key_class = algs.EGPublicKey
-    secret_key_class = algs.EGSecretKey
-    ciphertext_class = algs.EGCiphertext
-    proof_class = algs.EGZKProof
-    disjunctive_proof_class = algs.EGZKDisjunctiveProof
-
-
-class ElGamalBallotGroupMembershipTests(BallotGroupMembershipTestsMixin, TestCase):
-    """
-    crypto.elgamal is the implementation a cast ballot actually deserializes into,
-    by way of datatypes.legacy.EGCiphertext
-    """
-    public_key_class = crypto_elgamal.PublicKey
-    secret_key_class = crypto_elgamal.SecretKey
-    ciphertext_class = crypto_elgamal.Ciphertext
-    proof_class = crypto_elgamal.ZKProof
-    disjunctive_proof_class = crypto_elgamal.ZKDisjunctiveProof
-    secret_key_public_key_attribute = 'public_key'
-
     def test_cast_ballots_deserialize_into_this_implementation(self):
-        self.assertIs(datatypes.legacy.EGCiphertext.WRAPPED_OBJ_CLASS, self.ciphertext_class)
+        self.assertIs(datatypes.legacy.EGCiphertext.WRAPPED_OBJ_CLASS, crypto_elgamal.Ciphertext)
+
+    def test_group_membership_check_agrees_across_implementations(self):
+        """
+        it was drift between the two ElGamal implementations that let this through
+        """
+        randomness = self.rand.randrange(self.q)
+        for ciphertext_class in (crypto_elgamal.Ciphertext, algs.EGCiphertext):
+            well_formed = self.encrypt(1, randomness)
+            outside = self.encrypt(1, randomness, outside_subgroup=True)
+            for ciphertext in (well_formed, outside):
+                ciphertext.__class__ = ciphertext_class
+
+            self.assertTrue(well_formed.check_group_membership(self.pk))
+            self.assertFalse(outside.check_group_membership(self.pk))
+
+    def test_dh_proof_verify_uses_the_moduli_it_is_given(self):
+        """
+        both implementations of the DH tuple proof must verify from their arguments
+        rather than from attributes the proof object does not carry
+        """
+        secret = self.rand.randrange(2, self.q)
+        for proof_class in (crypto_elgamal.ZKProof, algs.EGZKProof):
+            proof = proof_class.generate(self.g, self.pk.y, secret, self.p, self.q,
+                                         algs.EG_fiatshamir_challenge_generator)
+            self.assertTrue(proof.verify(
+                self.g, self.pk.y, pow(self.g, secret, self.p), pow(self.pk.y, secret, self.p),
+                self.p, self.q, algs.EG_fiatshamir_challenge_generator))
 
 
 class DatatypeTests(TestCase):

--- a/helios/tests.py
+++ b/helios/tests.py
@@ -4,6 +4,7 @@ Unit Tests for Helios
 
 import datetime
 import logging
+import random as stdlib_random
 import re
 import uuid
 from urllib.parse import urlencode
@@ -20,7 +21,9 @@ import helios.models as models
 import helios.utils as utils
 import helios.views as views
 from helios import tasks
-from helios.crypto import electionalgs
+from helios.crypto import algs, electionalgs
+from helios.crypto import elgamal as crypto_elgamal
+from helios.workflows import homomorphic
 from helios_auth import models as auth_models
 
 
@@ -504,6 +507,189 @@ class CastVoteModelTests(TestCase):
 
     def test_cast_vote(self):
         pass
+
+class BallotGroupMembershipTestsMixin(object):
+    """
+    Ballot verification must reject ciphertext elements that do not live in the
+    order-q subgroup. The Helios parameters use a 2048-bit p with a 256-bit q, so
+    p-1 has a large cofactor and elements of small order do exist; a proof of
+    knowledge alone does not pin alpha and beta down to the intended subgroup.
+
+    There are two ElGamal implementations in the tree, and only one of them is
+    reachable from a cast ballot, so every case here runs against both.
+    """
+    allow_database_queries = False
+
+    # filled in by the concrete subclasses
+    public_key_class = None
+    secret_key_class = None
+    ciphertext_class = None
+    proof_class = None
+    disjunctive_proof_class = None
+    secret_key_public_key_attribute = 'pk'
+
+    def setUp(self):
+        params = views.ELGAMAL_PARAMS
+        self.p, self.q, self.g = params.p, params.q, params.g
+
+        secret = stdlib_random.randrange(2, self.q)
+        self.pk = self.public_key_class()
+        self.pk.p, self.pk.q, self.pk.g = self.p, self.q, self.g
+        self.pk.y = pow(self.g, secret, self.p)
+
+        self.sk = self.secret_key_class()
+        self.sk.x = secret
+        setattr(self.sk, self.secret_key_public_key_attribute, self.pk)
+
+        self.plaintexts = homomorphic.EncryptedAnswer.generate_plaintexts(self.pk)
+
+        # p-1 has order 2, so it is a witness that p is not a safe prime
+        self.small_order_element = self.p - 1
+        self.assertEqual(pow(self.small_order_element, 2, self.p), 1)
+        self.assertNotEqual(pow(self.small_order_element, self.q, self.p), 1)
+
+    def encrypt(self, exponent, randomness, outside_subgroup=False):
+        """
+        encrypt g^exponent, optionally pushing alpha out of the order-q subgroup
+        """
+        ciphertext = self.ciphertext_class()
+        ciphertext.pk = self.pk
+        ciphertext.alpha = pow(self.g, randomness, self.p)
+        if outside_subgroup:
+            ciphertext.alpha = (ciphertext.alpha * self.small_order_element) % self.p
+        ciphertext.beta = (pow(self.pk.y, randomness, self.p) * pow(self.g, exponent, self.p)) % self.p
+        return ciphertext
+
+    def forge_disjunctive_proof(self, ciphertext, real_index, randomness):
+        """
+        Build a disjunctive proof for a ciphertext whose alpha carries a factor of
+        order 2. Every stored challenge is ground to be even, so that factor raised
+        to the challenge is 1 and drops out of each verification equation. Only a
+        couple of attempts per proof are needed, which is precisely why the subgroup
+        check cannot be left to the proof itself.
+        """
+        for _ in range(200):
+            proofs = [None] * len(self.plaintexts)
+            for index in range(len(self.plaintexts)):
+                if index != real_index:
+                    even_challenge = 2 * stdlib_random.randrange(1, self.q // 2)
+                    proofs[index] = ciphertext.simulate_encryption_proof(
+                        self.plaintexts[index], challenge=even_challenge)
+
+            commitment_randomness = stdlib_random.randrange(self.q)
+            real_proof = self.proof_class()
+            real_proof.commitment = {
+                'A': pow(self.g, commitment_randomness, self.p),
+                'B': pow(self.pk.y, commitment_randomness, self.p),
+            }
+            proofs[real_index] = real_proof
+
+            overall = algs.EG_disjunctive_challenge_generator([p.commitment for p in proofs])
+            simulated_sum = sum(proofs[i].challenge for i in range(len(proofs)) if i != real_index)
+            challenge = (overall - simulated_sum) % self.q
+
+            if challenge % 2:
+                continue
+
+            real_proof.challenge = challenge
+            real_proof.response = (commitment_randomness + randomness * challenge) % self.q
+            return self.disjunctive_proof_class(proofs)
+
+        self.fail("could not grind an even challenge")
+
+    def build_answer(self, outside_subgroup):
+        """
+        a single-question, two-answer ballot voting for the first answer
+        """
+        randomness = [stdlib_random.randrange(self.q) for _ in range(2)]
+        choices = [
+            self.encrypt(1, randomness[0], outside_subgroup=outside_subgroup),
+            self.encrypt(0, randomness[1]),
+        ]
+
+        answer = homomorphic.EncryptedAnswer()
+        answer.choices = choices
+
+        if outside_subgroup:
+            answer.individual_proofs = [
+                self.forge_disjunctive_proof(choices[0], 1, randomness[0]),
+                self.forge_disjunctive_proof(choices[1], 0, randomness[1]),
+            ]
+            answer.overall_proof = self.forge_disjunctive_proof(
+                choices[0] * choices[1], 1, (randomness[0] + randomness[1]) % self.q)
+        else:
+            answer.individual_proofs = [
+                choices[0].generate_disjunctive_encryption_proof(
+                    self.plaintexts, 1, randomness[0], algs.EG_disjunctive_challenge_generator),
+                choices[1].generate_disjunctive_encryption_proof(
+                    self.plaintexts, 0, randomness[1], algs.EG_disjunctive_challenge_generator),
+            ]
+            answer.overall_proof = (choices[0] * choices[1]).generate_disjunctive_encryption_proof(
+                self.plaintexts, 1, (randomness[0] + randomness[1]) % self.q,
+                algs.EG_disjunctive_challenge_generator)
+
+        return answer
+
+    def test_well_formed_answer_verifies(self):
+        answer = self.build_answer(outside_subgroup=False)
+        self.assertTrue(answer.verify(self.pk, min=0, max=1))
+
+    def test_answer_outside_subgroup_is_rejected(self):
+        answer = self.build_answer(outside_subgroup=True)
+
+        # the forged ballot is well formed apart from the subgroup violation:
+        # every proof equation still holds
+        self.assertNotEqual(pow(answer.choices[0].alpha, self.q, self.p), 1)
+        for choice_num, choice in enumerate(answer.choices):
+            choice.pk = self.pk
+            self.assertTrue(choice.verify_disjunctive_encryption_proof(
+                self.plaintexts, answer.individual_proofs[choice_num],
+                algs.EG_disjunctive_challenge_generator))
+
+        self.assertFalse(answer.verify(self.pk, min=0, max=1))
+
+    def test_check_group_membership_rejects_small_order_factor(self):
+        ciphertext = self.encrypt(1, stdlib_random.randrange(self.q), outside_subgroup=True)
+        self.assertFalse(ciphertext.check_group_membership(self.pk))
+
+    def test_decryption_factor_proof_verifies(self):
+        """
+        the DH tuple proof is reached when a trustee uploads its decryption; it must
+        use the p and q it is handed rather than attributes it does not carry
+        """
+        randomness = stdlib_random.randrange(self.q)
+        ciphertext = self.encrypt(1, randomness)
+
+        factor, proof = self.sk.decryption_factor_and_proof(ciphertext)
+
+        self.assertTrue(proof.verify(
+            self.pk.g, ciphertext.alpha, self.pk.y, factor, self.pk.p, self.pk.q,
+            algs.EG_fiatshamir_challenge_generator))
+
+
+class AlgsBallotGroupMembershipTests(BallotGroupMembershipTestsMixin, TestCase):
+    public_key_class = algs.EGPublicKey
+    secret_key_class = algs.EGSecretKey
+    ciphertext_class = algs.EGCiphertext
+    proof_class = algs.EGZKProof
+    disjunctive_proof_class = algs.EGZKDisjunctiveProof
+
+
+class ElGamalBallotGroupMembershipTests(BallotGroupMembershipTestsMixin, TestCase):
+    """
+    crypto.elgamal is the implementation a cast ballot actually deserializes into,
+    by way of datatypes.legacy.EGCiphertext
+    """
+    public_key_class = crypto_elgamal.PublicKey
+    secret_key_class = crypto_elgamal.SecretKey
+    ciphertext_class = crypto_elgamal.Ciphertext
+    proof_class = crypto_elgamal.ZKProof
+    disjunctive_proof_class = crypto_elgamal.ZKDisjunctiveProof
+    secret_key_public_key_attribute = 'public_key'
+
+    def test_cast_ballots_deserialize_into_this_implementation(self):
+        self.assertIs(datatypes.legacy.EGCiphertext.WRAPPED_OBJ_CLASS, self.ciphertext_class)
+
 
 class DatatypeTests(TestCase):
     fixtures = ['users.json', 'election.json']

--- a/helios/workflows/homomorphic.py
+++ b/helios/workflows/homomorphic.py
@@ -63,7 +63,11 @@ class EncryptedAnswer(WorkflowObject):
       choice = self.choices[choice_num]
       choice.pk = pk
       individual_proof = self.individual_proofs[choice_num]
-      
+
+      # verify that elements belong to the proper group
+      if not choice.check_group_membership(pk):
+        return False
+
       # verify the proof on the encryption of that choice
       if not choice.verify_disjunctive_encryption_proof(possible_plaintexts, individual_proof, algs.EG_disjunctive_challenge_generator):
         return False

--- a/heliosbooth/js/jscrypto/elgamal.js
+++ b/heliosbooth/js/jscrypto/elgamal.js
@@ -288,10 +288,34 @@ ElGamal.Ciphertext = Class.extend({
     return new ElGamal.DisjunctiveProof(proofs);
   },
   
+  // check that the ElGamal elements belong to the order-q subgroup of the
+  // group described by the public key
+  checkGroupMembership: function() {
+    var p_minus_one = this.pk.p.add(BigInt.ONE.negate());
+
+    if (this.alpha.equals(BigInt.ONE) || this.alpha.equals(p_minus_one))
+      return false;
+
+    if (this.beta.equals(BigInt.ONE) || this.beta.equals(p_minus_one))
+      return false;
+
+    if (!this.alpha.modPow(this.pk.q, this.pk.p).equals(BigInt.ONE))
+      return false;
+
+    if (!this.beta.modPow(this.pk.q, this.pk.p).equals(BigInt.ONE))
+      return false;
+
+    return true;
+  },
+
   verifyDisjunctiveProof: function(list_of_plaintexts, disj_proof, challenge_generator) {
     var result = true;
     var proofs = disj_proof.proofs;
     
+    // verify that elements belong to the proper group
+    if (!this.checkGroupMembership())
+      return false;
+
     // for loop because we want to bail out of the inner loop
     // if we fail one of the verifications.
     for (var i=0; i < list_of_plaintexts.length; i++) {

--- a/heliosverifier/js/jscrypto/elgamal.js
+++ b/heliosverifier/js/jscrypto/elgamal.js
@@ -288,10 +288,34 @@ ElGamal.Ciphertext = Class.extend({
     return new ElGamal.DisjunctiveProof(proofs);
   },
   
+  // check that the ElGamal elements belong to the order-q subgroup of the
+  // group described by the public key
+  checkGroupMembership: function() {
+    var p_minus_one = this.pk.p.add(BigInt.ONE.negate());
+
+    if (this.alpha.equals(BigInt.ONE) || this.alpha.equals(p_minus_one))
+      return false;
+
+    if (this.beta.equals(BigInt.ONE) || this.beta.equals(p_minus_one))
+      return false;
+
+    if (!this.alpha.modPow(this.pk.q, this.pk.p).equals(BigInt.ONE))
+      return false;
+
+    if (!this.beta.modPow(this.pk.q, this.pk.p).equals(BigInt.ONE))
+      return false;
+
+    return true;
+  },
+
   verifyDisjunctiveProof: function(list_of_plaintexts, disj_proof, challenge_generator) {
     var result = true;
     var proofs = disj_proof.proofs;
     
+    // verify that elements belong to the proper group
+    if (!this.checkGroupMembership())
+      return false;
+
     // for loop because we want to bail out of the inner loop
     // if we fail one of the verifications.
     for (var i=0; i < list_of_plaintexts.length; i++) {


### PR DESCRIPTION
Ballot verification is supposed to confirm that the submitted ciphertext elements belong to the order-q subgroup described by the election public key. That check exists in the codebase, but it sits on a code path that cast ballots do not reach.

## Why it was missed

There are three ElGamal implementations in the tree, and they have drifted apart.

`crypto/electionalgs.py` performs the check. A cast ballot never goes through it: `CastVote.vote` is a `legacy/EncryptedVote`, which `datatypes.legacy` maps onto `workflows.homomorphic.EncryptedVote` and `crypto.elgamal.Ciphertext`. Neither of those carried the check — `crypto.elgamal.Ciphertext` had no `check_group_membership` method at all.

## Changes

- Add `check_group_membership` to `crypto.elgamal.Ciphertext`, mirroring the existing implementation in `crypto.algs`.
- Call it from `workflows.homomorphic.EncryptedAnswer.verify`, mirroring the existing call in `crypto.electionalgs`.
- Add the equivalent check to `ElGamal.Ciphertext.verifyDisjunctiveProof` in the JavaScript booth and verifier, which had the same gap. The two copies of `elgamal.js` are identical before and after.

Two tidy-ups to neighbouring verification code, both found while testing the above:

- `crypto.algs.EGZKProof.verify` referenced `self.pk`, which `EGZKProof` does not carry, so it raised `AttributeError` on every call. Introduced in c2904fb. This is latent rather than live — a trustee's uploaded decryption proofs deserialize into `crypto.elgamal.ZKProof` (`datatypes/legacy.py`), which reads its moduli from its arguments correctly — but the two implementations should not disagree. It now uses the `p` and `q` passed in.
- `crypto.elgamal` was missing the subgroup check on proof commitments that `crypto.algs` already performs. The two are now in line. This one is redundant with the membership check above rather than load-bearing, and is not separately tested for that reason.

## Tests

New tests construct a ballot whose `alpha` lies outside the subgroup but whose proof equations all still hold, and assert that verification rejects it — so the membership check is the only thing that can catch it. Two smaller cases assert that the two ElGamal implementations agree, since the drift between them is what let this through, plus one pinning down which implementation a cast ballot actually deserializes into.

The forgery is driven by a seeded RNG and is byte for byte identical on every run, so a failure reproduces exactly.

Each new test fails on `master` and passes here. Full suite: 203 tests, all passing (1 skipped — the LDAP test needs a reachable server).
