### PR TITLE
Add CSRF protection to state-changing views

### DIFF
--- a/helios/stats_views.py
+++ b/helios/stats_views.py
@@ -32,6 +32,8 @@ def home(request):
 
 def force_queue(request):
   user = require_admin(request)
+  check_csrf(request)
+
   votes_in_queue = CastVote.objects.filter(invalidated_at=None, verified_at=None)
   for cv in votes_in_queue:
     tasks.cast_vote_verify_and_store.delay(cv.id)

--- a/helios/templates/election_keygenerator.html
+++ b/helios/templates/election_keygenerator.html
@@ -160,6 +160,7 @@ Your key has been generated, but you may choose to<br /><a href="javascript:clea
 </div>
 
 <form method="post" id="pk_form" action="{% url "election@trustee@upload-pk" election.uuid trustee.uuid %}">
+<input type="hidden" name="csrf_token" value="{{csrf_token}}" />
 <h3>Your Public Key</h3>
 <p>
     It's time to upload the public key to the server.

--- a/helios/templates/election_view.html
+++ b/helios/templates/election_view.html
@@ -9,13 +9,25 @@
 <small><a class="small button" href="{% url "election@edit" election.uuid %}">edit</a></small>
 {% endif %}
 {% endif %}</h3>
-<p style="padding-top:0px; margin-top:0px">
+<!-- a div rather than a p: this block holds inline <form>s (the admin actions have to
+     be POSTs so they can carry a CSRF token), and the parser would auto-close a <p> at
+     the first one. -->
+<div style="padding-top:0px; margin-top:0px; margin-bottom:1em">
 <em>{% if election.private_p %}private{%else%}public{% endif %}</em> {{ election.election_type }}{% if settings.SHOW_USER_INFO %} created by <u><b>{{election.admin.display_html_small|safe}}</b></u>{% endif %}
 {% if election.is_archived %}
 [archived]
 {% endif %}
 {% if admin_p %}
-&nbsp;{% if election.is_archived %}<a class="small button" href="{% url "election@archive" election_uuid=election.uuid %}?archive_p=0">unarchive it</a>{% else %}<a class="small button" href="{% url "election@archive" election_uuid=election.uuid %}?archive_p=1">archive it</a>{% endif %}
+&nbsp;<form class="inline-action" method="post" action="{% url "election@archive" election_uuid=election.uuid %}">
+<input type="hidden" name="csrf_token" value="{{csrf_token}}" />
+{% if election.is_archived %}
+<input type="hidden" name="archive_p" value="0" />
+<button type="submit" class="small button">unarchive it</button>
+{% else %}
+<input type="hidden" name="archive_p" value="1" />
+<button type="submit" class="small button">archive it</button>
+{% endif %}
+</form>
 {% if election.is_archived %}
 <form method="post" action="{% url "election@delete" election_uuid=election.uuid %}" style="display:inline;" onsubmit="return confirm('Are you sure you want to delete this election? Once deleted, only site administrators can restore it.');">
 <input type="hidden" name="csrf_token" value="{{csrf_token}}" />
@@ -23,7 +35,10 @@
 <button type="submit" class="small button">delete it</button>
 </form>
 {% endif %}
-<a class="small button" onclick="return window.confirm('Are you sure you want to copy this election?');" href="{% url "election@copy" election_uuid=election.uuid %}">copy</a>
+<form class="inline-action" method="post" action="{% url "election@copy" election_uuid=election.uuid %}" onsubmit="return window.confirm('Are you sure you want to copy this election?');">
+<input type="hidden" name="csrf_token" value="{{csrf_token}}" />
+<button type="submit" class="small button">copy</button>
+</form>
 {% endif %}
 <br />
 {% if admin_p %}
@@ -31,17 +46,17 @@
 {% if election.featured_p %}
 this {{election.election_type}} is featured on the front page.
 {% if can_feature_p %}
-[<a href="{% url "election@set-featured" election.uuid %}?featured_p=0">unfeature it</a>]
+[<form class="inline-action" method="post" action="{% url "election@set-featured" election.uuid %}"><input type="hidden" name="csrf_token" value="{{csrf_token}}" /><input type="hidden" name="featured_p" value="0" /><button type="submit" class="link-button">unfeature it</button></form>]
 {% endif %}
 {% else %}
 this {{election.election_type}} is <u>not</u> featured on the front page.
 {% if can_feature_p %}
-[<a href="{% url "election@set-featured" election.uuid %}?featured_p=1">feature it</a>]
+[<form class="inline-action" method="post" action="{% url "election@set-featured" election.uuid %}"><input type="hidden" name="csrf_token" value="{{csrf_token}}" /><input type="hidden" name="featured_p" value="1" /><button type="submit" class="link-button">feature it</button></form>]
 {% endif %}
 {% endif %}
 {% endif %}
 {% endif %}
-</p>
+</div>
 
 </div>
 

--- a/helios/templates/list_trustees.html
+++ b/helios/templates/list_trustees.html
@@ -39,7 +39,10 @@
 
 {% else %}
 {% for t in trustees %}
-<h5> Trustee #{{forloop.counter}}: {{t.name}} 
+<!-- the action forms sit alongside the heading rather than inside it: a <form> is flow
+     content, which an <h5> is not allowed to contain. -->
+<div class="trustee-heading">
+<h5>Trustee #{{forloop.counter}}: {{t.name}}</h5>
 {% if admin_p %}
 {% if t.secret_key %}
 {% if not election.frozen_at %}[<form class="inline-action" method="post" action="{% url "election@trustees@delete" election.uuid %}" onsubmit="return confirm('Are you sure you want to remove Helios as a trustee?');"><input type="hidden" name="csrf_token" value="{{csrf_token}}" /><input type="hidden" name="uuid" value="{{t.uuid}}" /><button type="submit" class="link-button">x</button></form>]{% endif %}
@@ -49,7 +52,7 @@
 [<form class="inline-action" method="post" action="{% url "election@trustee@send-url" election.uuid t.uuid %}" onsubmit="return confirm('Are you sure you want to send this trustee his/her admin URL?');"><input type="hidden" name="csrf_token" value="{{csrf_token}}" /><button type="submit" class="link-button">send login</button></form>]
 {% endif %}
 {% endif %}
-</h5>
+</div>
 
 <p>
 {% if t.public_key_hash %}

--- a/helios/templates/list_trustees.html
+++ b/helios/templates/list_trustees.html
@@ -24,9 +24,12 @@
     [ <a onclick="return(confirm('Adding your own trustee requires a good bit more work to tally the election.\nYou will need to have trustees generate keypairs and safeguard their secret key.\n\nIf you are not sure what that means, we strongly recommend\nclicking Cancel and letting Helios tally the election for you.'));" href="{% url "election@trustees@new" election.uuid %}">add a trustee</a> ]
 </p>
 {% if not election.has_helios_trustee %}
-<p>
-    <a href="{% url "election@trustees@add-helios" election.uuid %}">add Helios as a trustee</a>
-</p>
+<div style="margin: 1em 0;">
+    <form class="inline-action" method="post" action="{% url "election@trustees@add-helios" election.uuid %}">
+    <input type="hidden" name="csrf_token" value="{{csrf_token}}" />
+    <button type="submit" class="link-button">add Helios as a trustee</button>
+    </form>
+</div>
 {% endif %}
 {% endif %}
 
@@ -39,11 +42,11 @@
 <h5> Trustee #{{forloop.counter}}: {{t.name}} 
 {% if admin_p %}
 {% if t.secret_key %}
-{% if not election.frozen_at %}[<a onclick="return confirm('Are you sure you want to remove Helios as a trustee?');" href="{% url "election@trustees@delete" election.uuid %}?uuid={{t.uuid}}">x</a>]{% endif %}
+{% if not election.frozen_at %}[<form class="inline-action" method="post" action="{% url "election@trustees@delete" election.uuid %}" onsubmit="return confirm('Are you sure you want to remove Helios as a trustee?');"><input type="hidden" name="csrf_token" value="{{csrf_token}}" /><input type="hidden" name="uuid" value="{{t.uuid}}" /><button type="submit" class="link-button">x</button></form>]{% endif %}
 {% else %}
 ({{t.email}})
-{% if not election.frozen_at %}[<a onclick="return confirm('Are you sure you want to remove this Trustee?');" href="{% url "election@trustees@delete" election.uuid %}?uuid={{t.uuid}}">x</a>]{% endif %}
-[<a onclick="return confirm('Are you sure you want to send this trustee his/her admin URL?');" href="{% url "election@trustee@send-url" election.uuid t.uuid %}">send login</a>]
+{% if not election.frozen_at %}[<form class="inline-action" method="post" action="{% url "election@trustees@delete" election.uuid %}" onsubmit="return confirm('Are you sure you want to remove this Trustee?');"><input type="hidden" name="csrf_token" value="{{csrf_token}}" /><input type="hidden" name="uuid" value="{{t.uuid}}" /><button type="submit" class="link-button">x</button></form>]{% endif %}
+[<form class="inline-action" method="post" action="{% url "election@trustee@send-url" election.uuid t.uuid %}" onsubmit="return confirm('Are you sure you want to send this trustee his/her admin URL?');"><input type="hidden" name="csrf_token" value="{{csrf_token}}" /><button type="submit" class="link-button">send login</button></form>]
 {% endif %}
 {% endif %}
 </h5>

--- a/helios/templates/stats.html
+++ b/helios/templates/stats.html
@@ -12,6 +12,6 @@
 <li> <a href="{% url "stats@elections-problems" %}">recent problem elections</a></li>
 </ul>
 
-<p><b>{{num_votes_in_queue}}</b> votes in queue. {% if num_votes_in_queue %}[<a href="{% url "stats@force-queue" %}">force it</a>]{% endif %}</p>
+<div><b>{{num_votes_in_queue}}</b> votes in queue. {% if num_votes_in_queue %}[<form class="inline-action" method="post" action="{% url "stats@force-queue" %}"><input type="hidden" name="csrf_token" value="{{csrf_token}}" /><button type="submit" class="link-button">force it</button></form>]{% endif %}</div>
 
 {% endblock %}

--- a/helios/templates/voters_list.html
+++ b/helios/templates/voters_list.html
@@ -161,7 +161,7 @@ Voters {{voters_page.start_index}} - {{voters_page.end_index}} (of {{total_voter
 [<span style="opacity: 0.5; cursor: not-allowed;" title="{{email_disabled_reason}}">email</span>]
 {% endif %}
 {% endif %}
-{% if can_modify_voters %}[<a onclick="return confirm('are you sure you want to remove {{voter.name}} ?');" href="{% url "election@voter@delete" election.uuid voter.uuid %}">x</a>]{% endif %}
+{% if can_modify_voters %}[<form class="inline-action" method="post" action="{% url "election@voter@delete" election.uuid voter.uuid %}" onsubmit="return confirm('are you sure you want to remove {{voter.name}} ?');"><input type="hidden" name="csrf_token" value="{{csrf_token}}" /><button type="submit" class="link-button">x</button></form>]{% endif %}
 </td>
 <td>{{voter.voter_login_id}}</td>
 <td>{{voter.voter_email}}</td>

--- a/helios/templates/voters_manage.html
+++ b/helios/templates/voters_manage.html
@@ -29,7 +29,7 @@ Voters {{offset_plus_one}} - {{offset_plus_limit}} &nbsp;&nbsp;
 <tr><td>{{voter.alias}}</td><td>{{voter.name}}</td><td>{{voter.voter_id}}
 {% if election.frozen_at %}
 {% else %}
-[<a onclick="return confirm('are you sure you want to remove {{voter.name}} ?');" href="{% url "election@voter@delete" election.uuid voter.uuid %}">x</a>]
+[<form class="inline-action" method="post" action="{% url "election@voter@delete" election.uuid voter.uuid %}" onsubmit="return confirm('are you sure you want to remove {{voter.name}} ?');"><input type="hidden" name="csrf_token" value="{{csrf_token}}" /><button type="submit" class="link-button">x</button></form>]
 {% endif %}
 </td></tr>
 {% endfor %}

--- a/helios/templates/voters_upload_confirm.html
+++ b/helios/templates/voters_upload_confirm.html
@@ -27,7 +27,6 @@ HOLD ON:<br />
 <input type="hidden" name="csrf_token" value="{{csrf_token}}" />
 <button type="submit" class="link-button">never mind, upload a different file</button>
 </form>
-</p>
 
 {% else %}
 <p></p>

--- a/helios/templates/voters_upload_confirm.html
+++ b/helios/templates/voters_upload_confirm.html
@@ -23,18 +23,25 @@ HOLD ON:<br />
 </p>
 <br />
 
-<a href="{% url "election@voters@upload-cancel" election.uuid %}">never mind, upload a different file</a>
+<form class="inline-action" method="post" action="{% url "election@voters@upload-cancel" election.uuid %}">
+<input type="hidden" name="csrf_token" value="{{csrf_token}}" />
+<button type="submit" class="link-button">never mind, upload a different file</button>
+</form>
 </p>
 
 {% else %}
 <p></p>
 <form method="post" action="" id="upload_form">
   Does this look right to you?
+  <input type="hidden" name="csrf_token" value="{{csrf_token}}" />
   <input type="hidden" name="confirm_p" value="1" />
   <input class="button" type="submit" value="Yes, let's go" />
 </form>
 
-<a href="{% url "election@voters@upload-cancel" election.uuid %}">no, let me upload a different file</a>
+<form class="inline-action" method="post" action="{% url "election@voters@upload-cancel" election.uuid %}">
+<input type="hidden" name="csrf_token" value="{{csrf_token}}" />
+<button type="submit" class="link-button">no, let me upload a different file</button>
+</form>
 
 {% endif %}
 

--- a/helios/test_csrf_smoke.py
+++ b/helios/test_csrf_smoke.py
@@ -1,0 +1,132 @@
+"""
+Regression tests for the CSRF hardening of state-changing views.
+
+Helios does not use Django's CsrfViewMiddleware; protection is opt-in per view via
+check_csrf(). These tests pin down the two properties that makes that safe for the
+views that used to be reachable by GET:
+
+  1. the view refuses a GET, a tokenless POST, and a POST with the wrong token; and
+  2. the template that drives it renders a POST form carrying the token.
+"""
+
+import re
+import uuid as uuidlib
+
+from django.test import Client, TestCase
+
+from helios import models
+from helios.views import ELGAMAL_PARAMS
+from helios_auth.models import User
+
+
+class CSRFProtectedActionTests(TestCase):
+  fixtures = ['users.json']
+
+  def setUp(self):
+    self.user = User.objects.get(user_id='ben@adida.net', user_type='google')
+    self.user.admin_p = True
+    self.user.save()
+
+    self.election, _ = models.Election.get_or_create(
+      short_name='csrf-smoke', name='CSRF Smoke', description='d', admin=self.user)
+    if not self.election.uuid:
+      self.election.uuid = str(uuidlib.uuid4())
+      self.election.save()
+
+    self.client = Client()
+    self.client.get("/")
+    session = self.client.session
+    session['user'] = {'type': self.user.user_type, 'user_id': self.user.user_id}
+    session.save()
+
+  @property
+  def csrf_token(self):
+    return self.client.session['csrf_token']
+
+  def election_url(self, path):
+    return "/helios/elections/%s%s" % (self.election.uuid, path)
+
+  def assertRejectsUnprotectedRequests(self, url, params):
+    """A GET, a tokenless POST, and a POST with a bad token must all be refused."""
+    self.assertEqual(self.client.get(url).status_code, 400,
+                     "GET should be refused: %s" % url)
+    self.assertEqual(self.client.post(url, params).status_code, 400,
+                     "POST without a token should be refused: %s" % url)
+    self.assertEqual(self.client.post(url, dict(params, csrf_token='wrong')).status_code, 400,
+                     "POST with a bad token should be refused: %s" % url)
+
+  def test_election_actions_require_a_csrf_protected_post(self):
+    cases = [
+      (self.election_url('/archive'), {'archive_p': '1'}),
+      (self.election_url('/set_featured'), {'featured_p': '1'}),
+      (self.election_url('/set_reg'), {'open_p': '1'}),
+      (self.election_url('/copy'), {}),
+      (self.election_url('/trustees/add-helios'), {}),
+    ]
+    for url, params in cases:
+      with self.subTest(url=url):
+        self.assertRejectsUnprotectedRequests(url, params)
+        response = self.client.post(url, dict(params, csrf_token=self.csrf_token))
+        self.assertEqual(response.status_code, 302,
+                         "a correctly signed POST should be accepted: %s" % url)
+
+  def test_voter_delete_requires_a_csrf_protected_post(self):
+    voter = models.Voter.objects.create(
+      uuid=str(uuidlib.uuid4()), election=self.election,
+      voter_email='voter@test.com', voter_name='Test Voter')
+    url = self.election_url('/voters/%s/delete' % voter.uuid)
+
+    self.assertRejectsUnprotectedRequests(url, {})
+    self.assertTrue(models.Voter.objects.filter(pk=voter.pk).exists(),
+                    "voter must survive every rejected request")
+
+    response = self.client.post(url, {'csrf_token': self.csrf_token})
+    self.assertEqual(response.status_code, 302)
+    self.assertFalse(models.Voter.objects.filter(pk=voter.pk).exists())
+
+  def test_trustee_actions_require_a_csrf_protected_post(self):
+    self.election.generate_trustee(ELGAMAL_PARAMS)
+    trustee = self.election.trustee_set.all()[0]
+
+    delete_url = self.election_url('/trustees/delete')
+    self.assertRejectsUnprotectedRequests(delete_url, {'uuid': trustee.uuid})
+    self.assertRejectsUnprotectedRequests(
+      self.election_url('/trustees/%s/sendurl' % trustee.uuid), {})
+
+    response = self.client.post(
+      delete_url, {'uuid': trustee.uuid, 'csrf_token': self.csrf_token})
+    self.assertEqual(response.status_code, 302)
+    self.assertFalse(self.election.trustee_set.filter(pk=trustee.pk).exists())
+
+  def test_voters_upload_cancel_requires_a_csrf_protected_post(self):
+    self.assertRejectsUnprotectedRequests(self.election_url('/voters/upload-cancel'), {})
+
+  def test_force_queue_requires_a_csrf_protected_post(self):
+    self.assertRejectsUnprotectedRequests("/helios/stats/force-queue", {})
+
+  def assertEveryFormIsProtected(self, html, url):
+    forms = re.findall(r'<form\b.*?</form>', html, re.S)
+    self.assertTrue(forms, "expected at least one form on %s" % url)
+    for form in forms:
+      self.assertIn('name="csrf_token"', form,
+                    "form without a csrf_token on %s: %s" % (url, form[:200]))
+
+  def test_admin_templates_render_protected_post_forms(self):
+    self.election.generate_trustee(ELGAMAL_PARAMS)
+    models.Voter.objects.create(
+      uuid=str(uuidlib.uuid4()), election=self.election,
+      voter_email='voter@test.com', voter_name='Test Voter')
+
+    for path in ['/view', '/trustees/view', '/voters/list']:
+      with self.subTest(path=path):
+        url = self.election_url(path)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEveryFormIsProtected(response.content.decode(), url)
+
+  def test_election_view_renders_the_admin_actions_as_forms(self):
+    response = self.client.get(self.election_url('/view'))
+    html = response.content.decode()
+    for path in ['/archive', '/copy']:
+      self.assertIn('action="%s"' % self.election_url(path), html,
+                    "%s should be driven by a POST form" % path)

--- a/helios/test_csrf_smoke.py
+++ b/helios/test_csrf_smoke.py
@@ -124,6 +124,34 @@ class CSRFProtectedActionTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEveryFormIsProtected(response.content.decode(), url)
 
+  def test_action_forms_are_not_nested_in_phrasing_only_elements(self):
+    """
+    A <form> is flow content, so it may not sit inside a <p> or an <h1>-<h6>. The
+    parser also silently closes a <p> at a <form>, which would move these actions
+    out of the block they appear to belong to.
+    """
+    try:
+      import html5lib
+    except ImportError:
+      self.skipTest("html5lib not installed")
+
+    self.election.generate_trustee(ELGAMAL_PARAMS)
+    models.Voter.objects.create(
+      uuid=str(uuidlib.uuid4()), election=self.election,
+      voter_email='voter@test.com', voter_name='Test Voter')
+
+    for path in ['/view', '/trustees/view', '/voters/list']:
+      with self.subTest(path=path):
+        response = self.client.get(self.election_url(path))
+        self.assertEqual(response.status_code, 200)
+        document = html5lib.parse(response.content.decode(), treebuilder="etree",
+                                  namespaceHTMLElements=False)
+        for tag in ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6']:
+          for element in document.iter(tag):
+            self.assertIsNone(
+              element.find('.//form'),
+              "a <form> is nested inside a <%s> on %s" % (tag, path))
+
   def test_election_view_renders_the_admin_actions_as_forms(self):
     response = self.client.get(self.election_url('/view'))
     html = response.content.decode()

--- a/helios/tests.py
+++ b/helios/tests.py
@@ -992,7 +992,8 @@ class ElectionBlackboxTests(WebTest):
         self.setup_login(from_scratch=True, user_id='mccio@github.com', user_type='google')
         response = self.client.get("/helios/stats/", follow=False)
         self.assertStatusCode(response, 200)
-        response = self.client.get("/helios/stats/force-queue", follow=False)
+        response = self.client.post("/helios/stats/force-queue", {
+                "csrf_token": self.client.session['csrf_token']}, follow=False)
         self.assertRedirects(response, "/helios/stats/")
         response = self.client.get("/helios/stats/elections", follow=False)
         self.assertStatusCode(response, 200)
@@ -1046,7 +1047,7 @@ class ElectionBlackboxTests(WebTest):
         # add a few voters with an improperly placed email address
         FILE = "helios/fixtures/voter-badfile.csv"
         voters_file = open(FILE)
-        response = self.client.post("/helios/elections/%s/voters/upload" % election_id, {'voters_file': voters_file})
+        response = self.client.post("/helios/elections/%s/voters/upload" % election_id, {'voters_file': voters_file, 'csrf_token': self.client.session['csrf_token']})
         voters_file.close()
         self.assertContains(response, "HOLD ON")
 
@@ -1056,18 +1057,18 @@ class ElectionBlackboxTests(WebTest):
         # I just needed some unicode quickly.
         FILE = "helios/fixtures/voter-file.csv"
         voters_file = open(FILE)
-        response = self.client.post("/helios/elections/%s/voters/upload" % election_id, {'voters_file': voters_file})
+        response = self.client.post("/helios/elections/%s/voters/upload" % election_id, {'voters_file': voters_file, 'csrf_token': self.client.session['csrf_token']})
         voters_file.close()
         self.assertContains(response, "first few rows of this file")
 
         # now we confirm the upload
-        response = self.client.post("/helios/elections/%s/voters/upload" % election_id, {'confirm_p': "1"})
+        response = self.client.post("/helios/elections/%s/voters/upload" % election_id, {'confirm_p': "1", 'csrf_token': self.client.session['csrf_token']})
         self.assertRedirects(response, "/helios/elections/%s/voters/list" % election_id)
 
         # Try a latin-1 encoded file
         FILE = "helios/fixtures/voter-file-latin1.csv"
         voters_file = open(FILE, mode='rb')
-        response = self.client.post("/helios/elections/%s/voters/upload" % election_id, {'voters_file': voters_file})
+        response = self.client.post("/helios/elections/%s/voters/upload" % election_id, {'voters_file': voters_file, 'csrf_token': self.client.session['csrf_token']})
         voters_file.close()
         self.assertContains(response, "first few rows of this file")
         
@@ -1341,14 +1342,14 @@ class ElectionBlackboxTests(WebTest):
         with open("helios/fixtures/voter-file.csv") as f:
             response = self.client.post(
                 "/helios/elections/%s/voters/upload" % election_id,
-                {"voters_file": f}
+                {"voters_file": f, "csrf_token": self.client.session["csrf_token"]}
             )
         self.assertContains(response, "first few rows")
 
         # Confirm first upload
         response = self.client.post(
             "/helios/elections/%s/voters/upload" % election_id,
-            {"confirm_p": "1"}
+            {"confirm_p": "1", "csrf_token": self.client.session["csrf_token"]}
         )
         self.assertRedirects(response, "/helios/elections/%s/voters/list" % election_id)
 
@@ -1362,14 +1363,14 @@ class ElectionBlackboxTests(WebTest):
         with open("helios/fixtures/voter-file-2.csv") as f:
             response = self.client.post(
                 "/helios/elections/%s/voters/upload" % election_id,
-                {"voters_file": f}
+                {"voters_file": f, "csrf_token": self.client.session["csrf_token"]}
             )
         self.assertContains(response, "first few rows")
 
         # Confirm second upload
         response = self.client.post(
             "/helios/elections/%s/voters/upload" % election_id,
-            {"confirm_p": "1"}
+            {"confirm_p": "1", "csrf_token": self.client.session["csrf_token"]}
         )
         self.assertRedirects(response, "/helios/elections/%s/voters/list" % election_id)
 
@@ -1416,14 +1417,14 @@ class ElectionBlackboxTests(WebTest):
         with open("helios/fixtures/voter-file.csv") as f:
             response = self.client.post(
                 "/helios/elections/%s/voters/upload" % election_id,
-                {"voters_file": f}
+                {"voters_file": f, "csrf_token": self.client.session["csrf_token"]}
             )
         self.assertContains(response, "first few rows")
 
         # Confirm upload
         response = self.client.post(
             "/helios/elections/%s/voters/upload" % election_id,
-            {"confirm_p": "1"}
+            {"confirm_p": "1", "csrf_token": self.client.session["csrf_token"]}
         )
         self.assertRedirects(response, "/helios/elections/%s/voters/list" % election_id)
 
@@ -1484,11 +1485,11 @@ class ElectionBlackboxTests(WebTest):
         with open("helios/fixtures/voter-file.csv") as f:
             self.client.post(
                 "/helios/elections/%s/voters/upload" % election_id,
-                {"voters_file": f}
+                {"voters_file": f, "csrf_token": self.client.session["csrf_token"]}
             )
         self.client.post(
             "/helios/elections/%s/voters/upload" % election_id,
-            {"confirm_p": "1"}
+            {"confirm_p": "1", "csrf_token": self.client.session["csrf_token"]}
         )
 
         # Add a question
@@ -3301,7 +3302,8 @@ class VoterDeleteRestrictionTests(WebTest):
         """Voter deletion should be allowed before tallying starts"""
         self.setup_login()
         response = self.client.post("/helios/elections/%s/voters/%s/delete" % (
-            self.election.uuid, self.voter.uuid))
+            self.election.uuid, self.voter.uuid),
+            {"csrf_token": self.client.session["csrf_token"]})
         # Should redirect (302) on successful deletion
         self.assertStatusCode(response, 302)
 
@@ -3312,7 +3314,8 @@ class VoterDeleteRestrictionTests(WebTest):
         self.election.save()
 
         response = self.client.post("/helios/elections/%s/voters/%s/delete" % (
-            self.election.uuid, self.voter.uuid))
+            self.election.uuid, self.voter.uuid),
+            {"csrf_token": self.client.session["csrf_token"]})
         self.assertStatusCode(response, 403)
 
     def test_voters_list_shows_delete_button_when_allowed(self):
@@ -3321,8 +3324,8 @@ class VoterDeleteRestrictionTests(WebTest):
 
         response = self.client.get("/helios/elections/%s/voters/list" % self.election.uuid)
         self.assertStatusCode(response, 200)
-        # Check for the delete link with [x] text
-        self.assertContains(response, '>x</a>]')
+        # Check for the delete [x] button (a POST form, so that it carries a CSRF token)
+        self.assertContains(response, '>x</button></form>]')
 
     def test_voters_list_hides_delete_button_when_blocked(self):
         """Voter list should hide delete [x] button when tallying has started"""
@@ -3332,6 +3335,6 @@ class VoterDeleteRestrictionTests(WebTest):
 
         response = self.client.get("/helios/elections/%s/voters/list" % self.election.uuid)
         self.assertStatusCode(response, 200)
-        # Check that the delete link is not present
-        self.assertNotContains(response, '>x</a>]')
+        # Check that the delete button is not present
+        self.assertNotContains(response, '>x</button></form>]')
 

--- a/helios/views.py
+++ b/helios/views.py
@@ -414,12 +414,16 @@ def new_trustee_helios(request, election):
   """
   Make Helios a trustee of the election
   """
+  check_csrf(request)
+
   election.generate_trustee(ELGAMAL_PARAMS)
   return HttpResponseRedirect(settings.SECURE_URL_HOST + reverse(url_names.election.ELECTION_TRUSTEES_VIEW, args=[election.uuid]))
   
 @election_admin(frozen=False)
 def delete_trustee(request, election):
-  trustee = Trustee.get_by_election_and_uuid(election, request.GET['uuid'])
+  check_csrf(request)
+
+  trustee = Trustee.get_by_election_and_uuid(election, request.POST['uuid'])
   trustee.delete()
   return HttpResponseRedirect(settings.SECURE_URL_HOST + reverse(url_names.election.ELECTION_TRUSTEES_VIEW, args=[election.uuid]))
 
@@ -568,8 +572,10 @@ def trustee_login(request, election_short_name, trustee_email, trustee_secret):
 
 @election_admin()
 def trustee_send_url(request, election, trustee_uuid):
+  check_csrf(request)
+
   trustee = Trustee.get_by_election_and_uuid(election, trustee_uuid)
-  
+
   url = settings.SECURE_URL_HOST + reverse(url_names.TRUSTEE_LOGIN, args=[election.short_name, trustee.email, trustee.secret])
   
   body = """
@@ -600,6 +606,8 @@ def trustee_check_sk(request, election, trustee):
 @trustee_check
 def trustee_upload_pk(request, election, trustee):
   if request.method == "POST":
+    check_csrf(request)
+
     # get the public key and the hash, and add it
     public_key_and_proof = utils.from_json(request.POST['public_key_json'])
     trustee.public_key = algs.EGPublicKey.fromJSONDict(public_key_and_proof['public_key'])
@@ -693,6 +701,8 @@ def password_voter_login(request, election):
                             'password_login_form': password_login_form,
                             'bad_voter_login' : bad_voter_login})
   
+  check_csrf(request)
+
   login_url = request.GET.get('login_url', None)
 
   if not login_url:
@@ -1057,6 +1067,8 @@ def voter_delete(request, election, voter_uuid):
   blocked once tallying has started or election has been tallied,
   as modifying voters after vote counting begins would compromise election integrity.
   """
+  check_csrf(request)
+
   can_delete, _ = election.can_modify_voters()
   if not can_delete:
     raise PermissionDenied()
@@ -1117,9 +1129,11 @@ def one_election_set_reg(request, election):
   """
   Set whether this is open registration or not
   """
+  check_csrf(request)
+
   # only allow this for public elections
   if not election.private_p:
-    open_p = bool(int(request.GET['open_p']))
+    open_p = bool(int(request.POST['open_p']))
     election.openreg = open_p
     election.save()
   
@@ -1130,12 +1144,13 @@ def one_election_set_featured(request, election):
   """
   Set whether this is a featured election or not
   """
+  check_csrf(request)
 
   user = get_user(request)
   if not user_can_feature_election(user, election):
     raise PermissionDenied()
 
-  featured_p = bool(int(request.GET['featured_p']))
+  featured_p = bool(int(request.POST['featured_p']))
   election.featured_p = featured_p
   election.save()
   
@@ -1143,8 +1158,9 @@ def one_election_set_featured(request, election):
 
 @election_admin()
 def one_election_archive(request, election):
+  check_csrf(request)
 
-  archive_p = request.GET.get('archive_p', True)
+  archive_p = request.POST.get('archive_p', True)
 
   if bool(int(archive_p)):
     election.archived_at = datetime.datetime.utcnow()
@@ -1171,9 +1187,8 @@ def one_election_delete(request, election):
 
 @election_admin()
 def one_election_copy(request, election):
-  # FIXME: make this a POST and CSRF protect it
-  # check_csrf(request)
-  
+  check_csrf(request)
+
   # new short name by uuid, because it's easier and the user can change it.
   new_uuid = uuid.uuid4()
   new_short_name = new_uuid
@@ -1396,8 +1411,8 @@ def one_election_set_result_and_proof(request, election):
   if election.tally_type != "homomorphic" or election.encrypted_tally == None:
     return HttpResponseRedirect(settings.SECURE_URL_HOST + reverse(url_names.election.ELECTION_VIEW, args=[election.election_id]))
 
-  # FIXME: check csrf
-  
+  check_csrf(request)
+
   election.result = utils.from_json(request.POST['result'])
   election.result_proof = utils.from_json(request.POST['result_proof'])
   election.save()
@@ -1603,6 +1618,8 @@ def voters_eligibility(request, election):
     # this shouldn't happen, only POSTs
     return HttpResponseRedirect("/")
 
+  check_csrf(request)
+
   # for now, private elections cannot change eligibility
   if election.private_p:
     return HttpResponseRedirect(settings.SECURE_URL_HOST + reverse(voters_list_pretty, args=[election.uuid]))
@@ -1644,6 +1661,8 @@ def voters_upload(request, election):
     return render_template(request, 'voters_upload', {'election': election, 'error': request.GET.get('e',None)})
     
   if request.method == "POST":
+    check_csrf(request)
+
     if bool(request.POST.get('confirm_p', 0)):
       # launch the background task to parse that file
       tasks.voter_file_process.delay(voter_file_id = request.session['voter_file_id'])
@@ -1678,11 +1697,13 @@ def voters_upload_cancel(request, election):
   """
   cancel upload of CSV file
   """
+  check_csrf(request)
+
   voter_file_id = request.session.get('voter_file_id', None)
   if voter_file_id:
     vf = VoterFile.objects.get(id = voter_file_id)
     vf.delete()
-  del request.session['voter_file_id']
+    del request.session['voter_file_id']
 
   return HttpResponseRedirect(settings.SECURE_URL_HOST + reverse(url_names.election.ELECTION_VIEW, args=[election.uuid]))
 
@@ -1741,6 +1762,8 @@ def voters_email(request, election):
     if voter:
       email_form.fields['send_to'].widget = email_form.fields['send_to'].hidden_widget()
   else:
+    check_csrf(request)
+
     email_form = forms.EmailVotersForm(request.POST)
     
     if email_form.is_valid():

--- a/helios_auth/auth_systems/ldapauth.py
+++ b/helios_auth/auth_systems/ldapauth.py
@@ -31,12 +31,15 @@ def ldap_login_view(request):
     from helios_auth.view_utils import render_template
     from helios_auth.views import after
     from helios_auth.auth_systems.ldapbackend import backend
+    from helios_auth.security import check_csrf
 
     error = None
 
     if request.method == "GET":
         form = LoginForm()
     else:
+        check_csrf(request)
+
         form = LoginForm(request.POST)
 
         request.session['auth_system_name'] = 'ldap'

--- a/helios_auth/auth_systems/password.py
+++ b/helios_auth/auth_systems/password.py
@@ -45,12 +45,15 @@ def password_login_view(request):
   from helios_auth.view_utils import render_template
   from helios_auth.views import after
   from helios_auth.models import User
+  from helios_auth.security import check_csrf
 
   error = None
-  
+
   if request.method == "GET":
     form = LoginForm()
   else:
+    check_csrf(request)
+
     form = LoginForm(request.POST)
 
     # set this in case we came here straight from the multi-login chooser
@@ -80,10 +83,13 @@ def password_forgotten_view(request):
   """
   from helios_auth.view_utils import render_template
   from helios_auth.models import User
+  from helios_auth.security import check_csrf
 
   if request.method == "GET":
     return render_template(request, 'password/forgot', {'return_url': request.GET.get('return_url', '')})
   else:
+    check_csrf(request)
+
     username = request.POST['username']
     return_url = request.POST['return_url']
     

--- a/helios_auth/security/__init__.py
+++ b/helios_auth/security/__init__.py
@@ -6,8 +6,7 @@ Ben Adida (ben@adida.net)
 
 import uuid
 from django.conf import settings
-from django.core.exceptions import PermissionDenied
-from django.http import HttpResponseNotAllowed
+from django.core.exceptions import PermissionDenied, SuspiciousOperation
 from django.http import HttpResponseRedirect
 # nicely update the wrapper function
 from functools import update_wrapper
@@ -106,11 +105,17 @@ def get_user(request):
     return None  
 
 def check_csrf(request):
+  """
+  Raises SuspiciousOperation (which Django turns into a 400) when the request is
+  not a CSRF-protected POST. Both checks must raise rather than return: callers
+  invoke this as a bare statement, so a returned response would be discarded and
+  the view would keep going as if the check had passed.
+  """
   if request.method != "POST":
-    return HttpResponseNotAllowed("only a POST for this URL")
-    
-  if ('csrf_token' not in request.POST) or (request.POST['csrf_token'] != request.session['csrf_token']):
-    raise Exception("A CSRF problem was detected")
+    raise SuspiciousOperation("only a POST for this URL")
+
+  if ('csrf_token' not in request.POST) or (request.POST['csrf_token'] != request.session.get('csrf_token')):
+    raise SuspiciousOperation("A CSRF problem was detected")
 
 def save_in_session_across_logouts(request, field_name, field_value):
   fields_to_save = request.session.get(FIELDS_TO_SAVE, [])

--- a/helios_auth/tests.py
+++ b/helios_auth/tests.py
@@ -282,9 +282,14 @@ class LDAPAuthTests(TestCase):
 
     def test_ldap_view_login(self):
         """ test if authenticates using the auth system login view """
+        # prime the session so that it carries a csrf_token, the way rendering the
+        # login form would
+        self.client.get(reverse(ldap_views.ldap_login_view))
+
         resp = self.client.post(reverse(ldap_views.ldap_login_view), {
             'username' : self.username,
-            'password': self.password
+            'password': self.password,
+            'csrf_token': self.client.session['csrf_token']
             }, follow=True)
         self.assertEqual(resp.status_code, 200)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+    "html5lib>=1.1",
     "pytest>=8.0.0",
 ]
 

--- a/server_ui/media/main.css
+++ b/server_ui/media/main.css
@@ -2,3 +2,31 @@
 #contentbody {
   padding: 20px 30px 20px 30px;
 }
+
+/*
+  State-changing actions have to be POSTs so they can carry a CSRF token, but a
+  few of them (deleting a voter, deleting a trustee) read better as inline links
+  than as buttons. These rules let a <button> inside an inline form look like the
+  <a> it replaced.
+*/
+form.inline-action {
+  display: inline;
+  margin: 0;
+}
+
+button.link-button {
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+  color: #2ba6cb;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+button.link-button:hover {
+  text-decoration: underline;
+}

--- a/server_ui/media/main.css
+++ b/server_ui/media/main.css
@@ -30,3 +30,17 @@ button.link-button {
 button.link-button:hover {
   text-decoration: underline;
 }
+
+/*
+  The trustee heading carries those inline action forms next to the trustee's name.
+  They cannot live inside the <h5> (a form is flow content, a heading takes phrasing
+  content), so the heading is inlined and the wrapper keeps the block spacing.
+*/
+.trustee-heading {
+  margin: 1.25rem 0 0.5rem;
+}
+
+.trustee-heading h5 {
+  display: inline;
+  margin: 0;
+}

--- a/settings.py
+++ b/settings.py
@@ -113,6 +113,13 @@ if get_from_env('SSL', '0') == '1':
 
 SESSION_COOKIE_HTTPONLY = True
 
+# Set this explicitly rather than relying on the Django default: it is a load-bearing
+# part of our CSRF defense, since Helios does its own CSRF checking (check_csrf) rather
+# than using Django's CsrfViewMiddleware. 'Lax' keeps the session cookie off every
+# cross-site POST and off cross-site GET subresources (images, iframes, fetch), while
+# still allowing ordinary inbound links to Helios to stay logged in.
+SESSION_COOKIE_SAMESITE = get_from_env('SESSION_COOKIE_SAMESITE', 'Lax')
+
 # let's go with one year because that's the way to do it now
 STS = False
 if get_from_env('HSTS', '0') == '1':

--- a/uv.lock
+++ b/uv.lock
@@ -396,6 +396,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "html5lib" },
     { name = "pytest" },
 ]
 
@@ -426,7 +427,23 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=8.0.0" }]
+dev = [
+    { name = "html5lib", specifier = ">=1.1" },
+    { name = "pytest", specifier = ">=8.0.0" },
+]
+
+[[package]]
+name = "html5lib"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/b6/b55c3f49042f1df3dcd422b7f224f939892ee94f22abcf503a9b7339eaf2/html5lib-1.1.tar.gz", hash = "sha256:b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f", size = 272215, upload-time = "2020-06-22T23:32:38.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/dd/a834df6482147d48e225a49515aabc28974ad5a4ca3215c18a882565b028/html5lib-1.1-py2.py3-none-any.whl", hash = "sha256:0d78f8fde1c230e99fe37986a60526d7049ed4bf8a9fadbad5f00e22e58e041d", size = 112173, upload-time = "2020-06-22T23:32:36.781Z" },
+]
 
 [[package]]
 name = "idna"


### PR DESCRIPTION
Helios disables Django's `CsrfViewMiddleware` and protects views individually with `check_csrf()`. That is opt-in, and a number of state-changing views never opted in.

### `check_csrf()`

On a non-POST request it returned an `HttpResponseNotAllowed`, but all 19 callers invoke it as a bare statement, so the response was discarded and the view carried on as if the check had passed. Both branches now raise `SuspiciousOperation` (Django → 400), which also lets it serve as a "this must be a POST" filter. The token comparison reads the session with `.get()` so a missing token fails closed instead of raising `KeyError`.

### Views with side effects on GET

These were reachable by following a link, so a logged-in admin could be made to trigger them. Now POST-only, with the templates submitting inline forms that carry the token:

`voter_delete`, `delete_trustee`, `trustee_send_url`, `new_trustee_helios`, `one_election_copy`, `one_election_archive`, `one_election_set_featured`, `one_election_set_reg`, `voters_upload_cancel`, `force_queue`

`one_election_set_reg` is worth a look — it changes `openreg` via `?open_p=`, and nothing in the UI links to it.

### Views already POST-only but unchecked

Now call `check_csrf()`: `voters_email`, `voters_eligibility`, `voters_upload`, `trustee_upload_pk`, `password_voter_login`, `one_election_set_result_and_proof`, `ldap_login_view`, `password_login_view`, `password_forgotten_view`

### Also

- `SESSION_COOKIE_SAMESITE` set explicitly to `Lax` (env-overridable). Already the Django default, but it's load-bearing here and shouldn't be inherited silently.
- The markup around these actions moved from `p` to `div` in `election_view.html` and `stats.html`, and out of the `h5` in `list_trustees.html`. A `form` is flow content: the parser silently closes an open `p` when it reaches one (which would move these actions out of the block they appear to belong to), and neither a `p` nor a heading may contain one. `election_view.html` already had the `p` bug for the existing delete form.
- Fixes a latent `KeyError` in `voters_upload_cancel`, which unconditionally deleted a session key that may not be set.
- New `helios/test_csrf_smoke.py` covers three things: the views reject a GET, a tokenless POST and a badly-signed POST; the admin templates render their actions as POST forms carrying the token; and no rendered `form` ends up nested in a `p` or an `h1`-`h6` (parsed with html5lib, added as a dev dependency).

Existing tests that drove these endpoints were updated to send a token. Full suite passes on top of current master: 214 tests, 1 skip (the LDAP test, which needs a live LDAP server — skipped on master too).

### Left alone deliberately

`post_audited_ballot` and `trustee_upload_decryption` are `@election_view()` with no authentication at all — anyone can POST to them unauthenticated. CSRF is meaningless without a session privilege to ride, and a token check would break the booth without adding security. That's a missing-authorization issue, worth its own change.